### PR TITLE
Question Answering batched input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-bert"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 default-run = "rust-bert"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Next token prediction| | | |✅|✅|
 
 ## Ready-to-use pipelines
 
-Leveraging Huggingface's pipelines, ready to use end-to-end NLP pipelines are available as part of this crate. The following capabilities are currently available:
+Based on Huggingface's pipelines, ready to use end-to-end NLP pipelines are available as part of this crate. The following capabilities are currently available:
 #### 1. Question Answering
 Extractive question answering from a given question and context. DistilBERT model finetuned on SQuAD (Stanford Question Answering Dataset)
 
@@ -30,10 +30,10 @@ Extractive question answering from a given question and context. DistilBERT mode
                                                config_path,
                                                weights_path, device)?;
                                                         
-    let question = "Where does Amy live ?";
-    let context = "Amy lives in Amsterdam";
+    let question = String::from("Where does Amy live ?");
+    let context = String::from("Amy lives in Amsterdam");
 
-    let answers = qa_model.predict(question, context, 1);
+    let answers = qa_model.predict(QaInput { question, context }, 1, 32);
 ```
 
 Output:

--- a/examples/question_answering.rs
+++ b/examples/question_answering.rs
@@ -42,7 +42,7 @@ fn main() -> failure::Fallible<()> {
     let qa_input_2 = QaInput { question: question_2, context: context_2 };
 
 //    Get answer
-    let answers = qa_model.predict(&vec!(qa_input_1, qa_input_2), 1);
+    let answers = qa_model.predict(&vec!(qa_input_1, qa_input_2), 1, 32);
     println!("{:?}", answers);
     Ok(())
 }

--- a/examples/question_answering.rs
+++ b/examples/question_answering.rs
@@ -14,7 +14,7 @@ extern crate failure;
 extern crate dirs;
 
 use std::path::PathBuf;
-use rust_bert::pipelines::question_answering::QuestionAnsweringModel;
+use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, QaInput};
 use tch::Device;
 
 
@@ -34,11 +34,15 @@ fn main() -> failure::Fallible<()> {
                                                weights_path, device)?;
 
 //    Define input
-    let question = "Where does Amy live ?";
-    let context = "Amy lives in Amsterdam";
+    let question_1 = String::from("Where does Amy live ?");
+    let context_1 = String::from("Amy lives in Amsterdam");
+    let question_2 = String::from("Where does Eric live");
+    let context_2 = String::from("While Amy lives in Amsterdam, Eric is in The Hague.");
+    let qa_input_1 = QaInput { question: question_1, context: context_1 };
+    let qa_input_2 = QaInput { question: question_2, context: context_2 };
 
 //    Get answer
-    let answers = qa_model.predict(question, context, 1);
+    let answers = qa_model.predict(&vec!(qa_input_1, qa_input_2), 1);
     println!("{:?}", answers);
     Ok(())
 }

--- a/examples/squad.rs
+++ b/examples/squad.rs
@@ -17,10 +17,8 @@ use std::path::PathBuf;
 use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, squad_processor};
 use tch::Device;
 use std::env;
-use std::time::Instant;
 
 fn main() -> failure::Fallible<()> {
-    let now = Instant::now();
     //    Resources paths
     let mut home: PathBuf = dirs::home_dir().unwrap();
     home.push("rustbert");
@@ -41,8 +39,8 @@ fn main() -> failure::Fallible<()> {
     let qa_inputs = squad_processor(squad_path);
 
 //    Get answer
-    let answers = qa_model.predict(&qa_inputs, 1, 32);
+    let answers = qa_model.predict(&qa_inputs, 1, 64);
+    println!("Sample answer: {:?}", answers.first().unwrap());
     println!("{}", answers.len());
-    println!("{}", now.elapsed().as_secs());
     Ok(())
 }

--- a/examples/squad.rs
+++ b/examples/squad.rs
@@ -17,9 +17,10 @@ use std::path::PathBuf;
 use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, squad_processor};
 use tch::Device;
 use std::env;
-
+use std::time::Instant;
 
 fn main() -> failure::Fallible<()> {
+    let now = Instant::now();
     //    Resources paths
     let mut home: PathBuf = dirs::home_dir().unwrap();
     home.push("rustbert");
@@ -40,7 +41,8 @@ fn main() -> failure::Fallible<()> {
     let qa_inputs = squad_processor(squad_path);
 
 //    Get answer
-    let answers = qa_model.predict(&qa_inputs[0..5], 1);
-    println!("{:?}", answers);
+    let answers = qa_model.predict(&qa_inputs, 1, 32);
+    println!("{}", answers.len());
+    println!("{}", now.elapsed().as_secs());
     Ok(())
 }

--- a/examples/squad.rs
+++ b/examples/squad.rs
@@ -1,0 +1,46 @@
+// Copyright 2019-present, the HuggingFace Inc. team, The Google AI Language Team and Facebook, Inc.
+// Copyright 2019 Guillaume Becquin
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate failure;
+extern crate dirs;
+
+use std::path::PathBuf;
+use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, squad_processor};
+use tch::Device;
+use std::env;
+
+
+fn main() -> failure::Fallible<()> {
+    //    Resources paths
+    let mut home: PathBuf = dirs::home_dir().unwrap();
+    home.push("rustbert");
+    home.push("distilbert-qa");
+    let config_path = &home.as_path().join("config.json");
+    let vocab_path = &home.as_path().join("vocab.txt");
+    let weights_path = &home.as_path().join("model.ot");
+
+//    Set-up Question Answering model
+    let device = Device::cuda_if_available();
+    let qa_model = QuestionAnsweringModel::new(vocab_path,
+                                               config_path,
+                                               weights_path, device)?;
+
+//    Define input
+    let mut squad_path = PathBuf::from(env::var("squad_dataset").unwrap());
+    squad_path.push("dev-v2.0.json");
+    let qa_inputs = squad_processor(squad_path);
+
+//    Get answer
+    let answers = qa_model.predict(&qa_inputs[0..5], 1);
+    println!("{:?}", answers);
+    Ok(())
+}

--- a/examples/squad.rs
+++ b/examples/squad.rs
@@ -34,7 +34,8 @@ fn main() -> failure::Fallible<()> {
                                                weights_path, device)?;
 
 //    Define input
-    let mut squad_path = PathBuf::from(env::var("squad_dataset").unwrap());
+    let mut squad_path = PathBuf::from(env::var("squad_dataset")
+        .expect("Please set the \"squad_dataset\" environment variable pointing to the SQuAD dataset folder"));
     squad_path.push("dev-v2.0.json");
     let qa_inputs = squad_processor(squad_path);
 

--- a/src/pipelines/question_answering.rs
+++ b/src/pipelines/question_answering.rs
@@ -137,21 +137,6 @@ impl QuestionAnsweringModel {
         })
     }
 
-//    fn prepare_for_model(&self, question: &str, context: &str, example_index: i64) -> (QaExample, Vec<QaFeature>) {
-//        let qa_example = QaExample::new(question, context);
-////        let mut input_ids: Vec<Tensor> = vec!();
-////        let mut attention_masks: Vec<Tensor> = vec!();
-//
-//        let features = self.generate_features(&qa_example, self.max_seq_len, self.doc_stride, self.max_query_length, example_index);
-////        for feature in &features {
-////            input_ids.push(Tensor::of_slice(&feature.input_ids).to(self.var_store.device()));
-////            attention_masks.push(Tensor::of_slice(&feature.attention_mask).to(self.var_store.device()));
-////        }
-////        let input_ids = Tensor::stack(&input_ids, 0);
-////        let attention_masks = Tensor::stack(&attention_masks, 0);
-//        (qa_example, features)
-//    }
-
     fn generate_batch_indices(&self, features: &Vec<QaFeature>, batch_size: usize) -> Vec<(usize, usize)> {
         let mut example_features_length: HashMap<i64, usize> = HashMap::new();
         for feature in features {

--- a/tests/distilbert.rs
+++ b/tests/distilbert.rs
@@ -6,7 +6,7 @@ use rust_tokenizers::bert_tokenizer::BertTokenizer;
 use rust_tokenizers::preprocessing::vocab::base_vocab::Vocab;
 use rust_bert::{SentimentClassifier, SentimentPolarity};
 use rust_bert::common::config::Config;
-use rust_bert::pipelines::question_answering::QuestionAnsweringModel;
+use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, QaInput};
 
 extern crate failure;
 extern crate dirs;
@@ -226,16 +226,18 @@ fn distilbert_question_answering() -> failure::Fallible<()> {
     let qa_model = QuestionAnsweringModel::new(vocab_path, config_path, weights_path, device)?;
 
 //    Define input
-    let question = "Where does Amy live ?";
-    let context = "Amy lives in Amsterdam";
+    let question = String::from("Where does Amy live ?");
+    let context = String::from("Amy lives in Amsterdam");
+    let qa_input = QaInput { question, context };
 
-    let answers = qa_model.predict(question, context, 1);
+    let answers = qa_model.predict(&vec!(qa_input), 1);
 
     assert_eq!(answers.len(), 1 as usize);
-    assert_eq!(answers[0].start, 13);
-    assert_eq!(answers[0].end, 21);
-    assert!((answers[0].score - 0.9977).abs() < 1e-4);
-    assert_eq!(answers[0].answer, "Amsterdam");
+    assert_eq!(answers[0].len(), 1 as usize);
+    assert_eq!(answers[0][0].start, 13);
+    assert_eq!(answers[0][0].end, 21);
+    assert!((answers[0][0].score - 0.9977).abs() < 1e-4);
+    assert_eq!(answers[0][0].answer, "Amsterdam");
 
     Ok(())
 }

--- a/tests/distilbert.rs
+++ b/tests/distilbert.rs
@@ -230,7 +230,7 @@ fn distilbert_question_answering() -> failure::Fallible<()> {
     let context = String::from("Amy lives in Amsterdam");
     let qa_input = QaInput { question, context };
 
-    let answers = qa_model.predict(&vec!(qa_input), 1);
+    let answers = qa_model.predict(&vec!(qa_input), 1, 32);
 
     assert_eq!(answers.len(), 1 as usize);
     assert_eq!(answers[0].len(), 1 as usize);


### PR DESCRIPTION
Updated the input for question answering pipeline to improve parallelization.
Entire datasets or batches of question/context pairs can be passed to the method and will be processed as batches