### PR TITLE
Updated dependencies to use latest tokenization crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-bert"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "Ready-to-use NLP pipelines and transformer-based models (BERT, DistilBERT, GPT2,...)"
@@ -30,8 +30,8 @@ all-tests = []
 features = [ "doc-only" ]
 
 [dependencies]
-rust_tokenizers = "2.0.4"
-tch = "0.1.6"
+rust_tokenizers = "2.0.5"
+tch = "0.1.7"
 serde_json = "1.0.51"
 serde = {version = "1.0.106", features = ["derive"]}
 failure = "0.1.7"


### PR DESCRIPTION
- Updated `rust_tokenizers` dependency to 2.0.5
- Updated `tch-rs` dependnecy to 0.1.7