### PR TITLE
Adapted to API changes in offset-aware rust-tokenizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-bert"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
 description = "Ready-to-use NLP pipelines and transformer-based models (BERT, DistilBERT, GPT2,...)"
@@ -30,8 +30,8 @@ all-tests = []
 features = [ "doc-only" ]
 
 [dependencies]
-rust_tokenizers = "2.0.5"
-tch = "0.1.7"
+rust_tokenizers = "~3.0.0"
+tch = "~0.1.7"
 serde_json = "1.0.51"
 serde = {version = "1.0.106", features = ["derive"]}
 failure = "0.1.7"

--- a/src/pipelines/generation.rs
+++ b/src/pipelines/generation.rs
@@ -605,6 +605,10 @@ mod private_generation_utils {
                 .zip(num_truncated_tokens)
                 .map(|(tokens, num_truncated_tokens)| truncate_sequences(tokens,
                                                                          None,
+                                                                         vec!(),
+                                                                         None,
+                                                                         vec!(),
+                                                                         None,
                                                                          num_truncated_tokens,
                                                                          &TruncationStrategy::LongestFirst,
                                                                          0).unwrap().0)

--- a/src/pipelines/question_answering.rs
+++ b/src/pipelines/question_answering.rs
@@ -410,7 +410,7 @@ impl QuestionAnsweringModel {
 
         let truncated_query = self.prepare_query(&qa_example.question, max_query_length);
 
-        let sequence_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), None,vec!(),None,vec!(),None).0.len();
+        let sequence_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), None, vec!(), None, vec!(), None).0.len();
         let sequence_pair_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), Some(vec!()), vec!(), Some(vec!()), vec!(), Some(vec!())).0.len();
 
         let mut spans: Vec<QaFeature> = vec!();
@@ -445,15 +445,15 @@ impl QuestionAnsweringModel {
     fn prepare_query(&self, query: &str, max_query_length: usize) -> Vec<i64> {
         let truncated_query = self.tokenizer.convert_tokens_to_ids(&self.tokenizer.tokenize(&query));
         let num_query_tokens_to_remove = if truncated_query.len() > max_query_length as usize { truncated_query.len() - max_query_length } else { 0 };
-        let (truncated_query, _, _,_,_,_,_,_) = truncate_sequences(truncated_query,
-                                                         None,
-                                                         vec!(),
-                                                         None,
-                                                         vec!(),
-                                                         None,
-                                                         num_query_tokens_to_remove,
-                                                         &TruncationStrategy::OnlyFirst,
-                                                         0).unwrap();
+        let (truncated_query, _, _, _, _, _, _, _) = truncate_sequences(truncated_query,
+                                                                        None,
+                                                                        vec!(),
+                                                                        None,
+                                                                        vec!(),
+                                                                        None,
+                                                                        num_query_tokens_to_remove,
+                                                                        &TruncationStrategy::OnlyFirst,
+                                                                        0).unwrap();
         truncated_query
     }
 
@@ -468,7 +468,7 @@ impl QuestionAnsweringModel {
         let total_len = len_1 + len_2 + sequence_pair_added_tokens;
         let num_truncated_tokens = if total_len > max_seq_length { total_len - max_seq_length } else { 0 };
 
-        let (truncated_query, truncated_context, _,_,_,_,overflowing_tokens,_)
+        let (truncated_query, truncated_context, _, _, _, _, overflowing_tokens, _)
             = truncate_sequences(truncated_query.clone(),
                                  Some(spans_token_ids.clone()),
                                  vec!(),

--- a/src/pipelines/question_answering.rs
+++ b/src/pipelines/question_answering.rs
@@ -47,6 +47,7 @@
 //! ```
 
 use rust_tokenizers::{BertTokenizer, Tokenizer, TruncationStrategy, TokenizedInput};
+use rust_tokenizers::preprocessing::tokenizer::base_tokenizer::Mask;
 use tch::{Device, Tensor, no_grad};
 use std::path::PathBuf;
 use rust_tokenizers::tokenization_utils::truncate_sequences;
@@ -409,8 +410,8 @@ impl QuestionAnsweringModel {
 
         let truncated_query = self.prepare_query(&qa_example.question, max_query_length);
 
-        let sequence_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), None).0.len();
-        let sequence_pair_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), Some(vec!())).0.len();
+        let sequence_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), None,vec!(),None,vec!(),None).0.len();
+        let sequence_pair_added_tokens = self.tokenizer.build_input_with_special_tokens(vec!(), Some(vec!()), vec!(), Some(vec!()), vec!(), Some(vec!())).0.len();
 
         let mut spans: Vec<QaFeature> = vec!();
 
@@ -444,7 +445,11 @@ impl QuestionAnsweringModel {
     fn prepare_query(&self, query: &str, max_query_length: usize) -> Vec<i64> {
         let truncated_query = self.tokenizer.convert_tokens_to_ids(&self.tokenizer.tokenize(&query));
         let num_query_tokens_to_remove = if truncated_query.len() > max_query_length as usize { truncated_query.len() - max_query_length } else { 0 };
-        let (truncated_query, _, _) = truncate_sequences(truncated_query,
+        let (truncated_query, _, _,_,_,_,_,_) = truncate_sequences(truncated_query,
+                                                         None,
+                                                         vec!(),
+                                                         None,
+                                                         vec!(),
                                                          None,
                                                          num_query_tokens_to_remove,
                                                          &TruncationStrategy::OnlyFirst,
@@ -463,21 +468,27 @@ impl QuestionAnsweringModel {
         let total_len = len_1 + len_2 + sequence_pair_added_tokens;
         let num_truncated_tokens = if total_len > max_seq_length { total_len - max_seq_length } else { 0 };
 
-        let (truncated_query, truncated_context, overflowing_tokens)
+        let (truncated_query, truncated_context, _,_,_,_,overflowing_tokens,_)
             = truncate_sequences(truncated_query.clone(),
                                  Some(spans_token_ids.clone()),
+                                 vec!(),
+                                 None,
+                                 vec!(),
+                                 None,
                                  num_truncated_tokens,
                                  &TruncationStrategy::OnlySecond,
                                  max_seq_length - doc_stride - len_1 - sequence_pair_added_tokens).unwrap();
 
-        let (mut token_ids, mut segment_ids, special_tokens_mask) = self.tokenizer.build_input_with_special_tokens(truncated_query, truncated_context);
+        let (mut token_ids, mut segment_ids, special_tokens_mask, mut token_offsets, mut mask) = self.tokenizer.build_input_with_special_tokens(truncated_query, truncated_context, vec!(), None, vec!(), None);
         let mut attention_mask = vec![1; token_ids.len()];
         if token_ids.len() < max_seq_length {
             token_ids.append(&mut vec![self.pad_idx; max_seq_length - token_ids.len()]);
             segment_ids.append(&mut vec![0; max_seq_length - segment_ids.len()]);
             attention_mask.append(&mut vec![0; max_seq_length - attention_mask.len()]);
+            token_offsets.append(&mut vec![None; max_seq_length - token_offsets.len()]);
+            mask.append(&mut vec![Mask::Special; max_seq_length - mask.len()]);
         }
-        (TokenizedInput { token_ids, segment_ids, special_tokens_mask, overflowing_tokens, num_truncated_tokens }, attention_mask)
+        (TokenizedInput { token_ids, segment_ids, special_tokens_mask, overflowing_tokens, num_truncated_tokens, token_offsets, mask }, attention_mask)
     }
 
     fn get_mask(&self, encoded_span: &TokenizedInput) -> Vec<i8> {

--- a/tests/openai_gpt.rs
+++ b/tests/openai_gpt.rs
@@ -93,7 +93,7 @@ fn openai_gpt_generation_greedy() -> failure::Fallible<()> {
     let output = model.generate(Some(vec!(input_context)), None);
 
     assert_eq!(output.len(), 1);
-    assert_eq!(output[0], "it was an intense machine dialogue. \n \" i \'m sorry, but we have to go now! the police are on their way and they\'re going after you - or at least that\'s what my");
+    assert_eq!(output[0], "it was an intense machine dialogue. \n \" i\'m sorry, but we have to go now! the police are on their way and they\'re going after you - or at least that\'s what my");
 
     Ok(())
 }
@@ -125,9 +125,9 @@ fn openai_gpt_generation_beam_search() -> failure::Fallible<()> {
     let output = model.generate(Some(vec!(input_context)), None);
 
     assert_eq!(output.len(), 3);
-    assert_eq!(output[0], "the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be right");
-    assert_eq!(output[1], "the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be back");
-    assert_eq!(output[2], "the dog isn\'t going anywhere. i \'m going to take care of him. \" \n \" i");
+    assert_eq!(output[0], "the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be right");
+    assert_eq!(output[1], "the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be back");
+    assert_eq!(output[2], "the dog isn\'t going anywhere. i\'m going to take care of him. \" \n \" i");
 
     Ok(())
 }
@@ -162,12 +162,12 @@ fn openai_gpt_generation_beam_search_multiple_prompts_without_padding() -> failu
     assert_eq!(output.len(), 6);
 
 //    Unpadded sequence (generation for `The dog is`) is identical to the
-    assert_eq!(output[0], "the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be right");
-    assert_eq!(output[1], "the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be back");
-    assert_eq!(output[2], "the dog isn\'t going anywhere. i \'m going to take care of him. \" \n \" i");
+    assert_eq!(output[0], "the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be right");
+    assert_eq!(output[1], "the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be back");
+    assert_eq!(output[2], "the dog isn\'t going anywhere. i\'m going to take care of him. \" \n \" i");
 
     assert_eq!(output[3], "the cat. \" \n \" i don\'t know what you\'re talking about. i don\'t");
-    assert_eq!(output[4], "the cat. \" \n \" i don\'t know what you\'re talking about. i \'m not");
+    assert_eq!(output[4], "the cat. \" \n \" i don\'t know what you\'re talking about. i\'m not");
     assert_eq!(output[5], "the cat. \" \n \" i don\'t know what you\'re talking about. i do know");
 
     Ok(())


### PR DESCRIPTION
This is a small PR that does the fixes some calls to be compatible with the offset-aware API in rust-tokenizer. (guillaume-be/rust-tokenizers#14 & guillaume-be/rust-tokenizers#19) 

There's still a little thing to fix I realized, probably in the tokenizers, because now some openai_gpt tests fail now, all on  the token "i\'m". 

```

failures:

---- openai_gpt_generation_beam_search stdout ----
thread 'openai_gpt_generation_beam_search' panicked at 'assertion failed: `(left == right)`
  left: `"the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be right"`,
 right: `"the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be right"`', tests/openai_gpt.rs:128:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- openai_gpt_generation_greedy stdout ----
thread 'openai_gpt_generation_greedy' panicked at 'assertion failed: `(left == right)`
  left: `"it was an intense machine dialogue. \n \" i\'m sorry, but we have to go now! the police are on their way and they\'re going after you - or at least that\'s what my"`,
 right: `"it was an intense machine dialogue. \n \" i \'m sorry, but we have to go now! the police are on their way and they\'re going after you - or at least that\'s what my"`', tests/openai_gpt.rs:96:5

---- openai_gpt_generation_beam_search_multiple_prompts_without_padding stdout ----
thread 'openai_gpt_generation_beam_search_multiple_prompts_without_padding' panicked at 'assertion failed: `(left == right)`
  left: `"the dog isn\'t going anywhere. i\'m going to take care of him. i \'ll be right"`,
 right: `"the dog isn\'t going anywhere. i \'m going to take care of him. i \'ll be right"`', tests/openai_gpt.rs:165:5


failures:
    openai_gpt_generation_beam_search
    openai_gpt_generation_beam_search_multiple_prompts_without_padding
    openai_gpt_generation_greedy
```