### PR TITLE
Generic path argument

### DIFF
--- a/src/albert/albert.rs
+++ b/src/albert/albert.rs
@@ -17,7 +17,7 @@ use crate::common::activations::{_gelu, _gelu_new, _mish, _relu, _tanh};
 use crate::common::dropout::Dropout;
 use crate::Config;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{borrow::Borrow, collections::HashMap};
 use tch::nn::Module;
 use tch::{nn, Kind, Tensor};
 
@@ -140,11 +140,16 @@ impl AlbertModel {
     /// let config = AlbertConfig::from_file(config_path);
     /// let albert: AlbertModel = AlbertModel::new(&(&p.root() / "albert"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertModel {
-        let embeddings = AlbertEmbeddings::new(&(p / "embeddings"), config);
-        let encoder = AlbertTransformer::new(&(p / "encoder"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertModel
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let embeddings = AlbertEmbeddings::new(p / "embeddings", config);
+        let encoder = AlbertTransformer::new(p / "encoder", config);
         let pooler = nn::linear(
-            &(p / "pooler"),
+            p / "pooler",
             config.hidden_size,
             config.hidden_size,
             Default::default(),
@@ -288,7 +293,12 @@ pub struct AlbertMLMHead {
 }
 
 impl AlbertMLMHead {
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertMLMHead {
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertMLMHead
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let layer_norm_eps = match config.layer_norm_eps {
             Some(value) => value,
             None => 1e-12,
@@ -298,18 +308,18 @@ impl AlbertMLMHead {
             ..Default::default()
         };
         let layer_norm = nn::layer_norm(
-            &(p / "LayerNorm"),
+            p / "LayerNorm",
             vec![config.embedding_size],
             layer_norm_config,
         );
         let dense = nn::linear(
-            &(p / "dense"),
+            p / "dense",
             config.hidden_size,
             config.embedding_size,
             Default::default(),
         );
         let decoder = nn::linear(
-            &(p / "decoder"),
+            p / "decoder",
             config.embedding_size,
             config.vocab_size,
             Default::default(),
@@ -368,9 +378,14 @@ impl AlbertForMaskedLM {
     /// let config = AlbertConfig::from_file(config_path);
     /// let albert: AlbertForMaskedLM = AlbertForMaskedLM::new(&p.root(), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertForMaskedLM {
-        let albert = AlbertModel::new(&(p / "albert"), config);
-        let predictions = AlbertMLMHead::new(&(p / "predictions"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertForMaskedLM
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let albert = AlbertModel::new(p / "albert", config);
+        let predictions = AlbertMLMHead::new(p / "predictions", config);
 
         AlbertForMaskedLM {
             albert,
@@ -486,8 +501,13 @@ impl AlbertForSequenceClassification {
     /// let albert: AlbertForSequenceClassification =
     ///     AlbertForSequenceClassification::new(&p.root(), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertForSequenceClassification {
-        let albert = AlbertModel::new(&(p / "albert"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertForSequenceClassification
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let albert = AlbertModel::new(p / "albert", config);
         let classifier_dropout_prob = match config.classifier_dropout_prob {
             Some(value) => value,
             None => 0.1,
@@ -499,7 +519,7 @@ impl AlbertForSequenceClassification {
             .expect("num_labels not provided in configuration")
             .len() as i64;
         let classifier = nn::linear(
-            &(p / "classifier"),
+            p / "classifier",
             config.hidden_size,
             num_labels,
             Default::default(),
@@ -621,8 +641,13 @@ impl AlbertForTokenClassification {
     /// let albert: AlbertForTokenClassification =
     ///     AlbertForTokenClassification::new(&p.root(), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertForTokenClassification {
-        let albert = AlbertModel::new(&(p / "albert"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertForTokenClassification
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let albert = AlbertModel::new(p / "albert", config);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let num_labels = config
             .id2label
@@ -630,7 +655,7 @@ impl AlbertForTokenClassification {
             .expect("num_labels not provided in configuration")
             .len() as i64;
         let classifier = nn::linear(
-            &(p / "classifier"),
+            p / "classifier",
             config.hidden_size,
             num_labels,
             Default::default(),
@@ -750,11 +775,16 @@ impl AlbertForQuestionAnswering {
     /// let config = AlbertConfig::from_file(config_path);
     /// let albert: AlbertForQuestionAnswering = AlbertForQuestionAnswering::new(&p.root(), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertForQuestionAnswering {
-        let albert = AlbertModel::new(&(p / "albert"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertForQuestionAnswering
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let albert = AlbertModel::new(p / "albert", config);
         let num_labels = 2;
         let qa_outputs = nn::linear(
-            &(p / "qa_outputs"),
+            p / "qa_outputs",
             config.hidden_size,
             num_labels,
             Default::default(),
@@ -880,12 +910,17 @@ impl AlbertForMultipleChoice {
     /// let config = AlbertConfig::from_file(config_path);
     /// let albert: AlbertForMultipleChoice = AlbertForMultipleChoice::new(&p.root(), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertForMultipleChoice {
-        let albert = AlbertModel::new(&(p / "albert"), config);
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertForMultipleChoice
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let albert = AlbertModel::new(p / "albert", config);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let num_labels = 1;
         let classifier = nn::linear(
-            &(p / "classifier"),
+            p / "classifier",
             config.hidden_size,
             num_labels,
             Default::default(),

--- a/src/albert/embeddings.rs
+++ b/src/albert/embeddings.rs
@@ -13,6 +13,7 @@
 
 use crate::albert::AlbertConfig;
 use crate::common::dropout::Dropout;
+use std::borrow::Borrow;
 use tch::nn::{embedding, EmbeddingConfig};
 use tch::{nn, Kind, Tensor};
 
@@ -28,7 +29,12 @@ pub struct AlbertEmbeddings {
 }
 
 impl AlbertEmbeddings {
-    pub fn new(p: &nn::Path, config: &AlbertConfig) -> AlbertEmbeddings {
+    pub fn new<'p, P>(p: P, config: &AlbertConfig) -> AlbertEmbeddings
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let embedding_config = EmbeddingConfig {
             padding_idx: config.pad_token_id,
             ..Default::default()

--- a/src/bert/attention.rs
+++ b/src/bert/attention.rs
@@ -14,6 +14,7 @@
 use crate::bert::bert::{Activation, BertConfig};
 use crate::common::activations::{_gelu, _mish, _relu};
 use crate::common::dropout::Dropout;
+use std::borrow::Borrow;
 use tch::kind::Kind::Float;
 use tch::{nn, Tensor};
 
@@ -141,7 +142,12 @@ pub struct BertSelfOutput {
 }
 
 impl BertSelfOutput {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> BertSelfOutput {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> BertSelfOutput
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let linear = nn::linear(
             p / "dense",
             config.hidden_size,
@@ -179,9 +185,14 @@ pub struct BertAttention {
 }
 
 impl BertAttention {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> BertAttention {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> BertAttention
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let _self = BertSelfAttention::new(p / "self", config);
-        let output = BertSelfOutput::new(&(p / "output"), config);
+        let output = BertSelfOutput::new(p / "output", config);
         BertAttention { _self, output }
     }
 
@@ -212,7 +223,12 @@ pub struct BertIntermediate {
 }
 
 impl BertIntermediate {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> BertIntermediate {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> BertIntermediate
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let lin = nn::linear(
             p / "dense",
             config.hidden_size,
@@ -239,7 +255,12 @@ pub struct BertOutput {
 }
 
 impl BertOutput {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> BertOutput {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> BertOutput
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let lin = nn::linear(
             p / "dense",
             config.intermediate_size,

--- a/src/bert/embeddings.rs
+++ b/src/bert/embeddings.rs
@@ -13,13 +13,16 @@
 
 use crate::bert::bert::BertConfig;
 use crate::common::dropout::Dropout;
+use std::borrow::Borrow;
 use tch::nn::{embedding, EmbeddingConfig};
 use tch::{nn, Kind, Tensor};
 
 /// # BertEmbedding trait (for use in BertModel or RoBERTaModel)
 /// Defines an interface for the embedding layers in BERT-based models
 pub trait BertEmbedding {
-    fn new(p: &nn::Path, config: &BertConfig) -> Self;
+    fn new<'p, P>(p: P, config: &BertConfig) -> Self
+    where
+        P: Borrow<nn::Path<'p>>;
 
     fn forward_t(
         &self,
@@ -64,7 +67,12 @@ impl BertEmbedding for BertEmbeddings {
     /// let config = BertConfig::from_file(config_path);
     /// let bert_embeddings = BertEmbeddings::new(&(&p.root() / "bert_embeddings"), &config);
     /// ```
-    fn new(p: &nn::Path, config: &BertConfig) -> BertEmbeddings {
+    fn new<'p, P>(p: P, config: &BertConfig) -> BertEmbeddings
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let embedding_config = EmbeddingConfig {
             padding_idx: 0,
             ..Default::default()

--- a/src/distilbert/embeddings.rs
+++ b/src/distilbert/embeddings.rs
@@ -12,6 +12,7 @@
 
 use crate::common::dropout::Dropout;
 use crate::distilbert::distilbert::DistilBertConfig;
+use std::borrow::Borrow;
 use tch::kind::Kind::Float;
 use tch::nn::{embedding, EmbeddingConfig, ModuleT};
 use tch::{nn, Device, Kind, Tensor};
@@ -63,7 +64,12 @@ pub struct DistilBertEmbedding {
 }
 
 impl DistilBertEmbedding {
-    pub fn new(p: &nn::Path, config: &DistilBertConfig) -> DistilBertEmbedding {
+    pub fn new<'p, P>(p: P, config: &DistilBertConfig) -> DistilBertEmbedding
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let embedding_config = EmbeddingConfig {
             padding_idx: 0,
             ..Default::default()

--- a/src/electra/embeddings.rs
+++ b/src/electra/embeddings.rs
@@ -14,6 +14,7 @@
 
 use crate::common::dropout::Dropout;
 use crate::electra::electra::ElectraConfig;
+use std::borrow::Borrow;
 use tch::nn::{embedding, EmbeddingConfig};
 use tch::{nn, Kind, Tensor};
 
@@ -28,7 +29,12 @@ pub struct ElectraEmbeddings {
 }
 
 impl ElectraEmbeddings {
-    pub fn new(p: &nn::Path, config: &ElectraConfig) -> ElectraEmbeddings {
+    pub fn new<'p, P>(p: P, config: &ElectraConfig) -> ElectraEmbeddings
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let embedding_config = EmbeddingConfig {
             padding_idx: config.pad_token_id,
             ..Default::default()

--- a/src/gpt2/gpt2.rs
+++ b/src/gpt2/gpt2.rs
@@ -18,7 +18,7 @@ use crate::gpt2::transformer::Block;
 use crate::pipelines::generation::{Cache, LMHeadModel};
 use crate::Config;
 use serde::{Deserialize, Serialize};
-use std::borrow::BorrowMut;
+use std::borrow::{Borrow, BorrowMut};
 use tch::kind::Kind::Int64;
 use tch::nn::embedding;
 use tch::{nn, Tensor};
@@ -247,16 +247,20 @@ impl Gpt2Model {
     /// let config = Gpt2Config::from_file(config_path);
     /// let gpt2: Gpt2Model = Gpt2Model::new(&(&p.root() / "gpt2"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &Gpt2Config) -> Gpt2Model {
-        let p = &(p / "transformer");
+    pub fn new<'p, P>(p: P, config: &Gpt2Config) -> Gpt2Model
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow() / "transformer";
+
         let wte = embedding(
-            &(p / "wte"),
+            &p / "wte",
             config.vocab_size,
             config.n_embd,
             Default::default(),
         );
         let wpe = embedding(
-            &(p / "wpe"),
+            &p / "wpe",
             config.n_positions,
             config.n_embd,
             Default::default(),
@@ -271,11 +275,11 @@ impl Gpt2Model {
             eps: config.layer_norm_epsilon,
             ..Default::default()
         };
-        let ln_f = nn::layer_norm(p / "ln_f", vec![config.n_embd], layer_norm_config);
+        let ln_f = nn::layer_norm(&p / "ln_f", vec![config.n_embd], layer_norm_config);
         let mut h: Vec<Block> = vec![];
-        let h_path = &(p / "h");
+        let h_path = &p / "h";
         for layer_index in 0..config.n_layer {
-            h.push(Block::new(&(h_path / layer_index), config, true));
+            h.push(Block::new(&h_path / layer_index, config, true));
         }
         let output_attentions = match config.output_attentions {
             Some(value) => value,
@@ -531,10 +535,15 @@ impl GPT2LMHeadModel {
     /// let config = Gpt2Config::from_file(config_path);
     /// let gpt2: GPT2LMHeadModel = GPT2LMHeadModel::new(&(&p.root() / "gpt2"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &Gpt2Config) -> GPT2LMHeadModel {
-        let transformer = Gpt2Model::new(&p, config);
+    pub fn new<'p, P>(p: P, config: &Gpt2Config) -> GPT2LMHeadModel
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let transformer = Gpt2Model::new(p, config);
         let lm_head = linear_no_bias(
-            &(p / "lm_head"),
+            p / "lm_head",
             config.n_embd,
             config.vocab_size,
             Default::default(),

--- a/src/marian/marian.rs
+++ b/src/marian/marian.rs
@@ -264,7 +264,7 @@ impl MarianForConditionalGeneration {
         config: &BartConfig,
         generation_mode: bool,
     ) -> MarianForConditionalGeneration {
-        let base_model = BartModel::new(&(p / "model"), config, generation_mode);
+        let base_model = BartModel::new(p / "model", config, generation_mode);
         let final_logits_bias = p.var(
             "final_logits_bias",
             &[1, config.vocab_size],

--- a/src/openai_gpt/openai_gpt.rs
+++ b/src/openai_gpt/openai_gpt.rs
@@ -17,7 +17,7 @@ use crate::common::linear::{linear_no_bias, LinearNoBias};
 use crate::gpt2::Gpt2Config;
 use crate::openai_gpt::transformer::Block;
 use crate::pipelines::generation::{Cache, LMHeadModel};
-use std::borrow::BorrowMut;
+use std::borrow::{Borrow, BorrowMut};
 use tch::kind::Kind::Int64;
 use tch::nn::embedding;
 use tch::{nn, Tensor};
@@ -106,15 +106,20 @@ impl OpenAiGptModel {
     /// let config = Gpt2Config::from_file(config_path);
     /// let gpt2: OpenAiGptModel = OpenAiGptModel::new(&(&p.root() / "gpt"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &Gpt2Config) -> OpenAiGptModel {
+    pub fn new<'p, P>(p: P, config: &Gpt2Config) -> OpenAiGptModel
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let tokens_embed = embedding(
-            &(p / "tokens_embed"),
+            p / "tokens_embed",
             config.vocab_size,
             config.n_embd,
             Default::default(),
         );
         let positions_embed = embedding(
-            &(p / "positions_embed"),
+            p / "positions_embed",
             config.n_positions,
             config.n_embd,
             Default::default(),
@@ -126,9 +131,9 @@ impl OpenAiGptModel {
         };
         let drop = Dropout::new(embd_pdrop);
         let mut h: Vec<Block> = vec![];
-        let h_path = &(p / "h");
+        let h_path = p / "h";
         for layer_index in 0..config.n_layer {
-            h.push(Block::new(&(h_path / layer_index), config, true));
+            h.push(Block::new(&h_path / layer_index, config, true));
         }
         let output_attentions = match config.output_attentions {
             Some(value) => value,
@@ -317,10 +322,15 @@ impl OpenAIGPTLMHeadModel {
     /// let config = Gpt2Config::from_file(config_path);
     /// let gpt2: OpenAIGPTLMHeadModel = OpenAIGPTLMHeadModel::new(&(&p.root() / "gpt"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &Gpt2Config) -> OpenAIGPTLMHeadModel {
-        let transformer = OpenAiGptModel::new(&p, config);
+    pub fn new<'p, P>(p: P, config: &Gpt2Config) -> OpenAIGPTLMHeadModel
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let transformer = OpenAiGptModel::new(p, config);
         let lm_head = linear_no_bias(
-            &(p / "lm_head"),
+            p / "lm_head",
             config.n_embd,
             config.vocab_size,
             Default::default(),

--- a/src/pipelines/generation.rs
+++ b/src/pipelines/generation.rs
@@ -1661,7 +1661,7 @@ pub(crate) mod private_generation_utils {
                         assert!(
                             eos_token_ids.is_some() & pad_token_id.is_some(),
                             "EOS and Padding tokens need to be defined if the number of generated \
-                            beams is greater than the target number fo beams"
+                             beams is greater than the target number fo beams"
                         );
                         next_batch_beam.append(
                             &mut (0..num_beams)

--- a/src/roberta/embeddings.rs
+++ b/src/roberta/embeddings.rs
@@ -13,6 +13,7 @@
 
 use crate::bert::{BertConfig, BertEmbedding};
 use crate::common::dropout::Dropout;
+use std::borrow::Borrow;
 use tch::nn::{embedding, EmbeddingConfig};
 use tch::{nn, Kind, Tensor};
 
@@ -69,7 +70,12 @@ impl BertEmbedding for RobertaEmbeddings {
     /// let config = BertConfig::from_file(config_path);
     /// let robert_embeddings = RobertaEmbeddings::new(&(&p.root() / "bert_embeddings"), &config);
     /// ```
-    fn new(p: &nn::Path, config: &BertConfig) -> RobertaEmbeddings {
+    fn new<'p, P>(p: P, config: &BertConfig) -> RobertaEmbeddings
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
         let embedding_config = EmbeddingConfig {
             padding_idx: 1,
             ..Default::default()

--- a/src/roberta/roberta.rs
+++ b/src/roberta/roberta.rs
@@ -16,6 +16,7 @@ use crate::common::activations::_gelu;
 use crate::common::dropout::Dropout;
 use crate::common::linear::{linear_no_bias, LinearNoBias};
 use crate::roberta::embeddings::RobertaEmbeddings;
+use std::borrow::Borrow;
 use tch::nn::Init;
 use tch::{nn, Tensor};
 
@@ -71,7 +72,11 @@ pub struct RobertaLMHead {
 }
 
 impl RobertaLMHead {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaLMHead {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaLMHead
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
         let dense = nn::linear(
             p / "dense",
             config.hidden_size,
@@ -88,7 +93,7 @@ impl RobertaLMHead {
             layer_norm_config,
         );
         let decoder = linear_no_bias(
-            &(p / "decoder"),
+            p / "decoder",
             config.hidden_size,
             config.vocab_size,
             Default::default(),
@@ -144,9 +149,14 @@ impl RobertaForMaskedLM {
     /// let config = BertConfig::from_file(config_path);
     /// let roberta = RobertaForMaskedLM::new(&(&p.root() / "roberta"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaForMaskedLM {
-        let roberta = BertModel::<RobertaEmbeddings>::new(&(p / "roberta"), config);
-        let lm_head = RobertaLMHead::new(&(p / "lm_head"), config);
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaForMaskedLM
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let lm_head = RobertaLMHead::new(p / "lm_head", config);
 
         RobertaForMaskedLM { roberta, lm_head }
     }
@@ -242,7 +252,11 @@ pub struct RobertaClassificationHead {
 }
 
 impl RobertaClassificationHead {
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaClassificationHead {
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaClassificationHead
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
         let dense = nn::linear(
             p / "dense",
             config.hidden_size,
@@ -313,9 +327,13 @@ impl RobertaForSequenceClassification {
     /// let config = BertConfig::from_file(config_path);
     /// let roberta = RobertaForSequenceClassification::new(&(&p.root() / "roberta"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaForSequenceClassification {
-        let roberta = BertModel::<RobertaEmbeddings>::new(&(p / "roberta"), config);
-        let classifier = RobertaClassificationHead::new(&(p / "classifier"), config);
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaForSequenceClassification
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let classifier = RobertaClassificationHead::new(p / "classifier", config);
 
         RobertaForSequenceClassification {
             roberta,
@@ -437,8 +455,12 @@ impl RobertaForMultipleChoice {
     /// let config = BertConfig::from_file(config_path);
     /// let roberta = RobertaForMultipleChoice::new(&(&p.root() / "roberta"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaForMultipleChoice {
-        let roberta = BertModel::<RobertaEmbeddings>::new(&(p / "roberta"), config);
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaForMultipleChoice
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let classifier = nn::linear(p / "classifier", config.hidden_size, 1, Default::default());
 
@@ -578,8 +600,12 @@ impl RobertaForTokenClassification {
     /// let config = BertConfig::from_file(config_path);
     /// let roberta = RobertaForTokenClassification::new(&(&p.root() / "roberta"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaForTokenClassification {
-        let roberta = BertModel::<RobertaEmbeddings>::new(&(p / "roberta"), config);
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaForTokenClassification
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let num_labels = config
             .id2label
@@ -715,8 +741,12 @@ impl RobertaForQuestionAnswering {
     /// let config = BertConfig::from_file(config_path);
     /// let roberta = RobertaForQuestionAnswering::new(&(&p.root() / "roberta"), &config);
     /// ```
-    pub fn new(p: &nn::Path, config: &BertConfig) -> RobertaForQuestionAnswering {
-        let roberta = BertModel::<RobertaEmbeddings>::new(&(p / "roberta"), config);
+    pub fn new<'p, P>(p: P, config: &BertConfig) -> RobertaForQuestionAnswering
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
         let num_labels = 2;
         let qa_outputs = nn::linear(
             p / "qa_outputs",


### PR DESCRIPTION
It replaces `p: &nn::Path<'p>` arguments with `p: P` where `P: Borrow<nn::Path<'p>>` such that the argument accepts both owned or borrowed type. It avoids wrapping around the brackets like `&(p / "name")`.