### PR TITLE
Updated local paths to avoid conflict with previous version

### DIFF
--- a/src/albert/albert.rs
+++ b/src/albert/albert.rs
@@ -33,7 +33,7 @@ pub struct AlbertVocabResources;
 impl AlbertModelResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/ALBERT. Modified with conversion to C-array format.
     pub const ALBERT_BASE_V2: (&'static str, &'static str) = (
-        "albert-base-v2/model.ot",
+        "albert-base-v2/model",
         "https://cdn.huggingface.co/albert-base-v2/rust_model.ot",
     );
 }
@@ -41,7 +41,7 @@ impl AlbertModelResources {
 impl AlbertConfigResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/ALBERT. Modified with conversion to C-array format.
     pub const ALBERT_BASE_V2: (&'static str, &'static str) = (
-        "albert-base-v2/config.json",
+        "albert-base-v2/config",
         "https://cdn.huggingface.co/albert-base-v2-config.json",
     );
 }
@@ -49,7 +49,7 @@ impl AlbertConfigResources {
 impl AlbertVocabResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/ALBERT. Modified with conversion to C-array format.
     pub const ALBERT_BASE_V2: (&'static str, &'static str) = (
-        "albert-base-v2/spiece.model",
+        "albert-base-v2/spiece",
         "https://cdn.huggingface.co/albert-base-v2-spiece.model",
     );
 }

--- a/src/bart/bart.rs
+++ b/src/bart/bart.rs
@@ -39,22 +39,22 @@ pub struct BartMergesResources;
 impl BartModelResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART: (&'static str, &'static str) = (
-        "bart/model.ot",
+        "bart/model",
         "https://cdn.huggingface.co/facebook/bart-large/rust_model.ot",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_CNN: (&'static str, &'static str) = (
-        "bart-cnn/model.ot",
+        "bart-cnn/model",
         "https://cdn.huggingface.co/facebook/bart-large-cnn/rust_model.ot",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_XSUM: (&'static str, &'static str) = (
-        "bart-xsum/model.ot",
+        "bart-xsum/model",
         "https://cdn.huggingface.co/facebook/bart-large-xsum/rust_model.ot",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_MNLI: (&'static str, &'static str) = (
-        "bart-large-mnli/model.ot",
+        "bart-large-mnli/model",
         "https://cdn.huggingface.co/facebook/bart-large-mnli/rust_model.ot",
     );
 }
@@ -62,22 +62,22 @@ impl BartModelResources {
 impl BartConfigResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART: (&'static str, &'static str) = (
-        "bart/config.json",
+        "bart/config",
         "https://cdn.huggingface.co/facebook/bart-large/config.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_CNN: (&'static str, &'static str) = (
-        "bart-cnn/config.json",
+        "bart-cnn/config",
         "https://cdn.huggingface.co/facebook/bart-large-cnn/config.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_XSUM: (&'static str, &'static str) = (
-        "bart-xsum/config.json",
+        "bart-xsum/config",
         "https://cdn.huggingface.co/facebook/bart-large-xsum/config.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_MNLI: (&'static str, &'static str) = (
-        "bart-large-mnli/config.json",
+        "bart-large-mnli/config",
         "https://cdn.huggingface.co/facebook/bart-large-mnli/config.json",
     );
 }
@@ -85,22 +85,22 @@ impl BartConfigResources {
 impl BartVocabResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART: (&'static str, &'static str) = (
-        "bart/vocab.txt",
+        "bart/vocab",
         "https://cdn.huggingface.co/roberta-large-vocab.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_CNN: (&'static str, &'static str) = (
-        "bart-cnn/vocab.txt",
+        "bart-cnn/vocab",
         "https://cdn.huggingface.co/roberta-large-vocab.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_XSUM: (&'static str, &'static str) = (
-        "bart-xsum/vocab.txt",
+        "bart-xsum/vocab",
         "https://cdn.huggingface.co/roberta-large-vocab.json",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_MNLI: (&'static str, &'static str) = (
-        "bart-large-mnli/vocab.txt",
+        "bart-large-mnli/vocab",
         "https://cdn.huggingface.co/roberta-large-vocab.json",
     );
 }
@@ -108,22 +108,22 @@ impl BartVocabResources {
 impl BartMergesResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART: (&'static str, &'static str) = (
-        "bart/merges.txt",
+        "bart/merges",
         "https://cdn.huggingface.co/roberta-large-merges.txt",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_CNN: (&'static str, &'static str) = (
-        "bart-cnn/merges.txt",
+        "bart-cnn/merges",
         "https://cdn.huggingface.co/roberta-large-merges.txt",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_XSUM: (&'static str, &'static str) = (
-        "bart-xsum/merges.txt",
+        "bart-xsum/merges",
         "https://cdn.huggingface.co/roberta-large-merges.txt",
     );
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const BART_MNLI: (&'static str, &'static str) = (
-        "bart-large-mnli/merges.txt",
+        "bart-large-mnli/merges",
         "https://cdn.huggingface.co/roberta-large-merges.txt",
     );
 }

--- a/src/bert/bert.rs
+++ b/src/bert/bert.rs
@@ -36,17 +36,17 @@ pub struct BertVocabResources;
 impl BertModelResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/bert. Modified with conversion to C-array format.
     pub const BERT: (&'static str, &'static str) = (
-        "bert/model.ot",
+        "bert/model",
         "https://cdn.huggingface.co/bert-base-uncased-rust_model.ot",
     );
     /// Shared under MIT license by the MDZ Digital Library team at the Bavarian State Library at https://github.com/dbmdz/berts. Modified with conversion to C-array format.
     pub const BERT_NER: (&'static str, &'static str) = (
-        "bert-ner/model.ot",
+        "bert-ner/model",
         "https://cdn.huggingface.co/dbmdz/bert-large-cased-finetuned-conll03-english/rust_model.ot",
     );
     /// Shared under Apache 2.0 license by Hugging Face Inc at https://github.com/huggingface/transformers/tree/master/examples/question-answering. Modified with conversion to C-array format.
     pub const BERT_QA: (&'static str, &'static str) = (
-        "bert-qa/model.ot",
+        "bert-qa/model",
         "https://cdn.huggingface.co/bert-large-cased-whole-word-masking-finetuned-squad-rust_model.ot",
     );
 }
@@ -54,17 +54,17 @@ impl BertModelResources {
 impl BertConfigResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/bert. Modified with conversion to C-array format.
     pub const BERT: (&'static str, &'static str) = (
-        "bert/config.json",
+        "bert/config",
         "https://cdn.huggingface.co/bert-base-uncased-config.json",
     );
     /// Shared under MIT license by the MDZ Digital Library team at the Bavarian State Library at https://github.com/dbmdz/berts. Modified with conversion to C-array format.
     pub const BERT_NER: (&'static str, &'static str) = (
-        "bert-ner/config.json",
+        "bert-ner/config",
         "https://cdn.huggingface.co/dbmdz/bert-large-cased-finetuned-conll03-english/config.json",
     );
     /// Shared under Apache 2.0 license by Hugging Face Inc at https://github.com/huggingface/transformers/tree/master/examples/question-answering. Modified with conversion to C-array format.
     pub const BERT_QA: (&'static str, &'static str) = (
-        "bert-qa/config.json",
+        "bert-qa/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-whole-word-masking-finetuned-squad-config.json",
     );
 }
@@ -72,17 +72,17 @@ impl BertConfigResources {
 impl BertVocabResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/bert. Modified with conversion to C-array format.
     pub const BERT: (&'static str, &'static str) = (
-        "bert/vocab.txt",
+        "bert/vocab",
         "https://cdn.huggingface.co/bert-base-uncased-vocab.txt",
     );
     /// Shared under MIT license by the MDZ Digital Library team at the Bavarian State Library at https://github.com/dbmdz/berts. Modified with conversion to C-array format.
     pub const BERT_NER: (&'static str, &'static str) = (
-        "bert-ner/vocab.txt",
+        "bert-ner/vocab",
         "https://cdn.huggingface.co/dbmdz/bert-large-cased-finetuned-conll03-english/vocab.txt",
     );
     /// Shared under Apache 2.0 license by Hugging Face Inc at https://github.com/huggingface/transformers/tree/master/examples/question-answering. Modified with conversion to C-array format.
     pub const BERT_QA: (&'static str, &'static str) = (
-        "bert-qa/vocab.txt",
+        "bert-qa/vocab",
         "https://cdn.huggingface.co/bert-large-cased-whole-word-masking-finetuned-squad-vocab.txt",
     );
 }

--- a/src/common/resources.rs
+++ b/src/common/resources.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 
 extern crate dirs;
 
-/// # Resource Enum expected by the `download_resource` function
+/// # Resource Enum pointing to model, configuration or vocabulary resources
 /// Can be of type:
 /// - LocalResource
 /// - RemoteResource
@@ -61,7 +61,6 @@ impl Resource {
             Resource::Remote(resource) => {
                 let cached_path =
                     CACHE.cached_path_in_subdir(&resource.url, Some(&resource.cache_subdir))?;
-                println!("Downloaded {} to {:?}", resource.url, cached_path);
                 Ok(cached_path)
             }
         }

--- a/src/distilbert/distilbert.rs
+++ b/src/distilbert/distilbert.rs
@@ -32,17 +32,17 @@ pub struct DistilBertVocabResources;
 impl DistilBertModelResources {
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SST2: (&'static str, &'static str) = (
-        "distilbert-sst2/model.ot",
+        "distilbert-sst2/model",
         "https://cdn.huggingface.co/distilbert-base-uncased-finetuned-sst-2-english-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT: (&'static str, &'static str) = (
-        "distilbert/model.ot",
+        "distilbert/model",
         "https://cdn.huggingface.co/distilbert-base-uncased-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SQUAD: (&'static str, &'static str) = (
-        "distilbert-qa/model.ot",
+        "distilbert-qa/model",
         "https://cdn.huggingface.co/distilbert-base-cased-distilled-squad-rust_model.ot",
     );
 }
@@ -50,17 +50,17 @@ impl DistilBertModelResources {
 impl DistilBertConfigResources {
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SST2: (&'static str, &'static str) = (
-        "distilbert-sst2/config.json",
+        "distilbert-sst2/config",
         "https://cdn.huggingface.co/distilbert-base-uncased-finetuned-sst-2-english-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT: (&'static str, &'static str) = (
-        "distilbert/config.json",
+        "distilbert/config",
         "https://cdn.huggingface.co/distilbert-base-uncased-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SQUAD: (&'static str, &'static str) = (
-        "distilbert-qa/config.json",
+        "distilbert-qa/config",
         "https://cdn.huggingface.co/distilbert-base-cased-distilled-squad-config.json",
     );
 }
@@ -68,17 +68,17 @@ impl DistilBertConfigResources {
 impl DistilBertVocabResources {
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SST2: (&'static str, &'static str) = (
-        "distilbert-sst2/vocab.txt",
+        "distilbert-sst2/vocab",
         "https://cdn.huggingface.co/distilbert-base-uncased-finetuned-sst-2-english-vocab.txt",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT: (&'static str, &'static str) = (
-        "distilbert/vocab.txt",
+        "distilbert/vocab",
         "https://cdn.huggingface.co/bert-base-uncased-vocab.txt",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_BERT_SQUAD: (&'static str, &'static str) = (
-        "distilbert-qa/vocab.txt",
+        "distilbert-qa/vocab",
         "https://cdn.huggingface.co/bert-large-cased-vocab.txt",
     );
 }

--- a/src/electra/electra.rs
+++ b/src/electra/electra.rs
@@ -34,12 +34,12 @@ pub struct ElectraVocabResources;
 impl ElectraModelResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_GENERATOR: (&'static str, &'static str) = (
-        "electra-base-generator/model.ot",
+        "electra-base-generator/model",
         "https://cdn.huggingface.co/google/electra-base-generator/rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_DISCRIMINATOR: (&'static str, &'static str) = (
-        "electra-base-discriminator/model.ot",
+        "electra-base-discriminator/model",
         "https://cdn.huggingface.co/google/electra-base-discriminator/rust_model.ot",
     );
 }
@@ -47,12 +47,12 @@ impl ElectraModelResources {
 impl ElectraConfigResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_GENERATOR: (&'static str, &'static str) = (
-        "electra-base-generator/config.json",
+        "electra-base-generator/config",
         "https://cdn.huggingface.co/google/electra-base-generator/config.json",
     );
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_DISCRIMINATOR: (&'static str, &'static str) = (
-        "electra-base-discriminator/config.json",
+        "electra-base-discriminator/config",
         "https://cdn.huggingface.co/google/electra-base-discriminator/config.json",
     );
 }
@@ -60,12 +60,12 @@ impl ElectraConfigResources {
 impl ElectraVocabResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_GENERATOR: (&'static str, &'static str) = (
-        "electra-base-generator/vocab.txt",
+        "electra-base-generator/vocab",
         "https://cdn.huggingface.co/google/electra-base-generator/vocab.txt",
     );
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/electra. Modified with conversion to C-array format.
     pub const BASE_DISCRIMINATOR: (&'static str, &'static str) = (
-        "electra-base-discriminator/vocab.txt",
+        "electra-base-discriminator/vocab",
         "https://cdn.huggingface.co/google/electra-base-discriminator/vocab.txt",
     );
 }

--- a/src/gpt2/gpt2.rs
+++ b/src/gpt2/gpt2.rs
@@ -38,131 +38,125 @@ pub struct Gpt2MergesResources;
 impl Gpt2ModelResources {
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2: (&'static str, &'static str) = (
-        "gpt2/model.ot",
+        "gpt2/model",
         "https://cdn.huggingface.co/gpt2-rust_model.ot",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_MEDIUM: (&'static str, &'static str) = (
-        "gpt2-medium/model.ot",
+        "gpt2-medium/model",
         "https://cdn.huggingface.co/gpt2-medium-rust_model.ot",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_LARGE: (&'static str, &'static str) = (
-        "gpt2-large/model.ot",
+        "gpt2-large/model",
         "https://cdn.huggingface.co/gpt2-large-rust_model.ot",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_XL: (&'static str, &'static str) = (
-        "gpt2-xl/model.ot",
+        "gpt2-xl/model",
         "https://cdn.huggingface.co/gpt2-xl-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_GPT2: (&'static str, &'static str) = (
-        "distilgpt2/model.ot",
+        "distilgpt2/model",
         "https://cdn.huggingface.co/distilgpt2-rust_model.ot",
     );
     /// Shared under MIT license by the Microsoft team at https://huggingface.co/microsoft/DialoGPT-medium. Modified with conversion to C-array format.
     pub const DIALOGPT_MEDIUM: (&'static str, &'static str) = (
-        "dialogpt-medium/model.ot",
+        "dialogpt-medium/model",
         "https://cdn.huggingface.co/microsoft/DialoGPT-medium/rust_model.ot",
     );
 }
 
 impl Gpt2ConfigResources {
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
-    pub const GPT2: (&'static str, &'static str) = (
-        "gpt2/config.json",
-        "https://cdn.huggingface.co/gpt2-config.json",
-    );
+    pub const GPT2: (&'static str, &'static str) =
+        ("gpt2/config", "https://cdn.huggingface.co/gpt2-config.json");
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_MEDIUM: (&'static str, &'static str) = (
-        "gpt2-medium/config.json",
+        "gpt2-medium/config",
         "https://cdn.huggingface.co/gpt2-medium-config.json",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_LARGE: (&'static str, &'static str) = (
-        "gpt2-large/config.json",
+        "gpt2-large/config",
         "https://cdn.huggingface.co/gpt2-large-config.json",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_XL: (&'static str, &'static str) = (
-        "gpt2-xl/config.json",
+        "gpt2-xl/config",
         "https://cdn.huggingface.co/gpt2-xl-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_GPT2: (&'static str, &'static str) = (
-        "distilgpt2/config.json",
+        "distilgpt2/config",
         "https://cdn.huggingface.co/distilgpt2-config.json",
     );
     /// Shared under MIT license by the Microsoft team at https://huggingface.co/microsoft/DialoGPT-medium. Modified with conversion to C-array format.
     pub const DIALOGPT_MEDIUM: (&'static str, &'static str) = (
-        "dialogpt-medium/config.json",
+        "dialogpt-medium/config",
         "https://cdn.huggingface.co/microsoft/DialoGPT-medium/config.json",
     );
 }
 
 impl Gpt2VocabResources {
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
-    pub const GPT2: (&'static str, &'static str) = (
-        "gpt2/vocab.txt",
-        "https://cdn.huggingface.co/gpt2-vocab.json",
-    );
+    pub const GPT2: (&'static str, &'static str) =
+        ("gpt2/vocab", "https://cdn.huggingface.co/gpt2-vocab.json");
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_MEDIUM: (&'static str, &'static str) = (
-        "gpt2-medium/vocab.txt",
+        "gpt2-medium/vocab",
         "https://cdn.huggingface.co/gpt2-medium-vocab.json",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_LARGE: (&'static str, &'static str) = (
-        "gpt2-large/vocab.txt",
+        "gpt2-large/vocab",
         "https://cdn.huggingface.co/gpt2-large-vocab.json",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_XL: (&'static str, &'static str) = (
-        "gpt2-xl/vocab.txt",
+        "gpt2-xl/vocab",
         "https://cdn.huggingface.co/gpt2-xl-vocab.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_GPT2: (&'static str, &'static str) = (
-        "distilgpt2/vocab.txt",
+        "distilgpt2/vocab",
         "https://cdn.huggingface.co/distilgpt2-vocab.json",
     );
     /// Shared under MIT license by the Microsoft team at https://huggingface.co/microsoft/DialoGPT-medium. Modified with conversion to C-array format.
     pub const DIALOGPT_MEDIUM: (&'static str, &'static str) = (
-        "dialogpt-medium/vocab.txt",
+        "dialogpt-medium/vocab",
         "https://cdn.huggingface.co/microsoft/DialoGPT-medium/vocab.json",
     );
 }
 
 impl Gpt2MergesResources {
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
-    pub const GPT2: (&'static str, &'static str) = (
-        "gpt2/merges.txt",
-        "https://cdn.huggingface.co/gpt2-merges.txt",
-    );
+    pub const GPT2: (&'static str, &'static str) =
+        ("gpt2/merges", "https://cdn.huggingface.co/gpt2-merges.txt");
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_MEDIUM: (&'static str, &'static str) = (
-        "gpt2-medium/merges.txt",
+        "gpt2-medium/merges",
         "https://cdn.huggingface.co/gpt2-medium-merges.txt",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_LARGE: (&'static str, &'static str) = (
-        "gpt2-large/merges.txt",
+        "gpt2-large/merges",
         "https://cdn.huggingface.co/gpt2-large-merges.txt",
     );
     /// Shared under Modified MIT license by the OpenAI team at https://github.com/openai/gpt-2/blob/master/LICENSE. Modified with conversion to C-array format.
     pub const GPT2_XL: (&'static str, &'static str) = (
-        "gpt2-xl/merges.txt",
+        "gpt2-xl/merges",
         "https://cdn.huggingface.co/gpt2-xl-merges.txt",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const DISTIL_GPT2: (&'static str, &'static str) = (
-        "distilgpt2/merges.txt",
+        "distilgpt2/merges",
         "https://cdn.huggingface.co/distilgpt2-merges.txt",
     );
     /// Shared under MIT license by the Microsoft team at https://huggingface.co/microsoft/DialoGPT-medium. Modified with conversion to C-array format.
     pub const DIALOGPT_MEDIUM: (&'static str, &'static str) = (
-        "dialogpt-medium/merges.txt",
+        "dialogpt-medium/merges",
         "https://cdn.huggingface.co/microsoft/DialoGPT-medium/merges.txt",
     );
 }

--- a/src/marian/marian.rs
+++ b/src/marian/marian.rs
@@ -35,42 +35,42 @@ pub struct MarianPrefix;
 impl MarianModelResources {
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const ENGLISH2ROMANCE: (&'static str, &'static str) = (
-        "marian-mt-en-ROMANCE/model.ot",
+        "marian-mt-en-ROMANCE/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ROMANCE/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const ROMANCE2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ROMANCE-en/model.ot",
+        "marian-mt-ROMANCE-en/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ROMANCE-en/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const ENGLISH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-en-de/model.ot",
+        "marian-mt-en-de/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-de/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const GERMAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-de-en/model.ot",
+        "marian-mt-de-en/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-en/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const ENGLISH2RUSSIAN: (&'static str, &'static str) = (
-        "marian-mt-en-ru/model.ot",
+        "marian-mt-en-ru/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ru/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const RUSSIAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ru-en/model.ot",
+        "marian-mt-ru-en/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ru-en/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const FRENCH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-fr-de/model.ot",
+        "marian-mt-fr-de/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-fr-de/rust_model.ot",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
     pub const GERMAN2FRENCH: (&'static str, &'static str) = (
-        "marian-mt-de-fr/model.ot",
+        "marian-mt-de-fr/model",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-fr/rust_model.ot",
     );
 }
@@ -78,42 +78,42 @@ impl MarianModelResources {
 impl MarianConfigResources {
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2ROMANCE: (&'static str, &'static str) = (
-        "marian-mt-en-ROMANCE/config.json",
+        "marian-mt-en-ROMANCE/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ROMANCE/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ROMANCE2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ROMANCE-en/config.json",
+        "marian-mt-ROMANCE-en/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ROMANCE-en/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-en-de/config.json",
+        "marian-mt-en-de/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-de/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-de-en/config.json",
+        "marian-mt-de-en/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-en/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2RUSSIAN: (&'static str, &'static str) = (
-        "marian-mt-en-ru/config.json",
+        "marian-mt-en-ru/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ru/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const RUSSIAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ru-en/config.json",
+        "marian-mt-ru-en/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ru-en/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const FRENCH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-fr-de/config.json",
+        "marian-mt-fr-de/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-fr-de/config.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2FRENCH: (&'static str, &'static str) = (
-        "marian-mt-de-fr/config.json",
+        "marian-mt-de-fr/config",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-fr/config.json",
     );
 }
@@ -121,42 +121,42 @@ impl MarianConfigResources {
 impl MarianVocabResources {
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2ROMANCE: (&'static str, &'static str) = (
-        "marian-mt-en-ROMANCE/vocab.json",
+        "marian-mt-en-ROMANCE/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ROMANCE/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ROMANCE2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ROMANCE-en/vocab.json",
+        "marian-mt-ROMANCE-en/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ROMANCE-en/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-en-de/vocab.json",
+        "marian-mt-en-de/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-de/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-de-en/vocab.json",
+        "marian-mt-de-en/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-en/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2RUSSIAN: (&'static str, &'static str) = (
-        "marian-mt-en-ru/vocab.json",
+        "marian-mt-en-ru/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ru/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const RUSSIAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ru-en/vocab.json",
+        "marian-mt-ru-en/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ru-en/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const FRENCH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-fr-de/vocab.json",
+        "marian-mt-fr-de/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-fr-de/vocab.json",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2FRENCH: (&'static str, &'static str) = (
-        "marian-mt-de-fr/vocab.json",
+        "marian-mt-de-fr/vocab",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-fr/vocab.json",
     );
 }
@@ -164,42 +164,42 @@ impl MarianVocabResources {
 impl MarianSpmResources {
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2ROMANCE: (&'static str, &'static str) = (
-        "marian-mt-en-ROMANCE/spiece.model",
+        "marian-mt-en-ROMANCE/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ROMANCE/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ROMANCE2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ROMANCE-en/spiece.model",
+        "marian-mt-ROMANCE-en/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ROMANCE-en/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-en-de/spiece.model",
+        "marian-mt-en-de/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-de/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-de-en/spiece.model",
+        "marian-mt-de-en/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-en/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const ENGLISH2RUSSIAN: (&'static str, &'static str) = (
-        "marian-mt-en-ru/spiece.model",
+        "marian-mt-en-ru/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-en-ru/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const RUSSIAN2ENGLISH: (&'static str, &'static str) = (
-        "marian-mt-ru-en/spiece.model",
+        "marian-mt-ru-en/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-ru-en/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const FRENCH2GERMAN: (&'static str, &'static str) = (
-        "marian-mt-fr-de/spiece.model",
+        "marian-mt-fr-de/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-fr-de/source.spm",
     );
     /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
     pub const GERMAN2FRENCH: (&'static str, &'static str) = (
-        "marian-mt-de-fr/spiece.model",
+        "marian-mt-de-fr/spiece",
         "https://cdn.huggingface.co/Helsinki-NLP/opus-mt-de-fr/source.spm",
     );
 }

--- a/src/openai_gpt/openai_gpt.rs
+++ b/src/openai_gpt/openai_gpt.rs
@@ -37,7 +37,7 @@ pub struct OpenAiGptMergesResources;
 impl OpenAiGptModelResources {
     /// Shared under MIT license by the OpenAI team at https://github.com/openai/finetune-transformer-lm. Modified with conversion to C-array format.
     pub const GPT: (&'static str, &'static str) = (
-        "openai-gpt/model.ot",
+        "openai-gpt/model",
         "https://cdn.huggingface.co/openai-gpt-rust_model.ot",
     );
 }
@@ -45,7 +45,7 @@ impl OpenAiGptModelResources {
 impl OpenAiGptConfigResources {
     /// Shared under MIT license by the OpenAI team at https://github.com/openai/finetune-transformer-lm. Modified with conversion to C-array format.
     pub const GPT: (&'static str, &'static str) = (
-        "openai-gpt/config.json",
+        "openai-gpt/config",
         "https://cdn.huggingface.co/openai-gpt-config.json",
     );
 }
@@ -53,7 +53,7 @@ impl OpenAiGptConfigResources {
 impl OpenAiGptVocabResources {
     /// Shared under MIT license by the OpenAI team at https://github.com/openai/finetune-transformer-lm. Modified with conversion to C-array format.
     pub const GPT: (&'static str, &'static str) = (
-        "openai-gpt/vocab.txt",
+        "openai-gpt/vocab",
         "https://cdn.huggingface.co/openai-gpt-vocab.json",
     );
 }
@@ -61,7 +61,7 @@ impl OpenAiGptVocabResources {
 impl OpenAiGptMergesResources {
     /// Shared under MIT license by the OpenAI team at https://github.com/openai/finetune-transformer-lm. Modified with conversion to C-array format.
     pub const GPT: (&'static str, &'static str) = (
-        "openai-gpt/merges.txt",
+        "openai-gpt/merges",
         "https://cdn.huggingface.co/openai-gpt-merges.txt",
     );
 }

--- a/src/roberta/roberta.rs
+++ b/src/roberta/roberta.rs
@@ -35,32 +35,32 @@ pub struct RobertaMergesResources;
 impl RobertaModelResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const ROBERTA: (&'static str, &'static str) = (
-        "roberta/model.ot",
+        "roberta/model",
         "https://cdn.huggingface.co/roberta-base-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by [deepset](https://deepset.ai) at https://huggingface.co/deepset/roberta-base-squad2. Modified with conversion to C-array format.
     pub const ROBERTA_QA: (&'static str, &'static str) = (
-        "roberta-qa/model.ot",
+        "roberta-qa/model",
         "https://cdn.huggingface.co/deepset/roberta-base-squad2/rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_EN: (&'static str, &'static str) = (
-        "xlm-roberta-ner-en/model.ot",
+        "xlm-roberta-ner-en/model",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll03-english-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_DE: (&'static str, &'static str) = (
-        "xlm-roberta-ner-de/model.ot",
+        "xlm-roberta-ner-de/model",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll03-german-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_NL: (&'static str, &'static str) = (
-        "xlm-roberta-ner-nl/model.ot",
+        "xlm-roberta-ner-nl/model",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll02-dutch-rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_ES: (&'static str, &'static str) = (
-        "xlm-roberta-ner-es/model.ot",
+        "xlm-roberta-ner-es/model",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll02-spanish-rust_model.ot",
     );
 }
@@ -68,32 +68,32 @@ impl RobertaModelResources {
 impl RobertaConfigResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const ROBERTA: (&'static str, &'static str) = (
-        "roberta/config.json",
+        "roberta/config",
         "https://cdn.huggingface.co/roberta-base-config.json",
     );
     /// Shared under Apache 2.0 license by [deepset](https://deepset.ai) at https://huggingface.co/deepset/roberta-base-squad2. Modified with conversion to C-array format.
     pub const ROBERTA_QA: (&'static str, &'static str) = (
-        "roberta-qa/config.json",
+        "roberta-qa/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/deepset/roberta-base-squad2/config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_EN: (&'static str, &'static str) = (
-        "xlm-roberta-ner-en/config.json",
+        "xlm-roberta-ner-en/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-large-finetuned-conll03-english-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_DE: (&'static str, &'static str) = (
-        "xlm-roberta-ner-de/config.json",
+        "xlm-roberta-ner-de/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-large-finetuned-conll03-german-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_NL: (&'static str, &'static str) = (
-        "xlm-roberta-ner-nl/config.json",
+        "xlm-roberta-ner-nl/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-large-finetuned-conll02-dutch-config.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_ES: (&'static str, &'static str) = (
-        "xlm-roberta-ner-es/config.json",
+        "xlm-roberta-ner-es/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/xlm-roberta-large-finetuned-conll02-spanish-config.json",
     );
 }
@@ -101,32 +101,32 @@ impl RobertaConfigResources {
 impl RobertaVocabResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const ROBERTA: (&'static str, &'static str) = (
-        "roberta/vocab.txt",
+        "roberta/vocab",
         "https://cdn.huggingface.co/roberta-base-vocab.json",
     );
     /// Shared under Apache 2.0 license by [deepset](https://deepset.ai) at https://huggingface.co/deepset/roberta-base-squad2. Modified with conversion to C-array format.
     pub const ROBERTA_QA: (&'static str, &'static str) = (
-        "roberta-qa/vocab.json",
+        "roberta-qa/vocab",
         "https://cdn.huggingface.co/deepset/roberta-base-squad2/vocab.json",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_EN: (&'static str, &'static str) = (
-        "xlm-roberta-ner-en/spiece.model",
+        "xlm-roberta-ner-en/spiece",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll03-english-sentencepiece.bpe.model",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_DE: (&'static str, &'static str) = (
-        "xlm-roberta-ner-de/spiece.model",
+        "xlm-roberta-ner-de/spiece",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll03-german-sentencepiece.bpe.model",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_NL: (&'static str, &'static str) = (
-        "xlm-roberta-ner-nl/spiece.model",
+        "xlm-roberta-ner-nl/spiece",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll02-dutch-sentencepiece.bpe.model",
     );
     /// Shared under Apache 2.0 license by the HuggingFace Inc. team at https://huggingface.co/models. Modified with conversion to C-array format.
     pub const XLM_ROBERTA_NER_ES: (&'static str, &'static str) = (
-        "xlm-roberta-ner-es/spiece.model",
+        "xlm-roberta-ner-es/spiece",
         "https://cdn.huggingface.co/xlm-roberta-large-finetuned-conll02-spanish-sentencepiece.bpe.model",
     );
 }
@@ -134,12 +134,12 @@ impl RobertaVocabResources {
 impl RobertaMergesResources {
     /// Shared under MIT license by the Facebook AI Research Fairseq team at https://github.com/pytorch/fairseq. Modified with conversion to C-array format.
     pub const ROBERTA: (&'static str, &'static str) = (
-        "roberta/merges.txt",
+        "roberta/merges",
         "https://cdn.huggingface.co/roberta-base-merges.txt",
     );
     /// Shared under Apache 2.0 license by [deepset](https://deepset.ai) at https://huggingface.co/deepset/roberta-base-squad2. Modified with conversion to C-array format.
     pub const ROBERTA_QA: (&'static str, &'static str) = (
-        "roberta-qa/merges.txt",
+        "roberta-qa/merges",
         "https://cdn.huggingface.co/deepset/roberta-base-squad2/merges.txt",
     );
 }

--- a/src/t5/t5.rs
+++ b/src/t5/t5.rs
@@ -33,12 +33,12 @@ pub struct T5Prefix;
 impl T5ModelResources {
     /// Shared under Apache 2.0 license by the T5 Authors at https://github.com/google-research/text-to-text-transfer-transformer. Modified with conversion to C-array format.
     pub const T5_SMALL: (&'static str, &'static str) = (
-        "t5-small/model.ot",
+        "t5-small/model",
         "https://cdn.huggingface.co/t5-small/rust_model.ot",
     );
     /// Shared under Apache 2.0 license by the T5 Authors at https://github.com/google-research/text-to-text-transfer-transformer. Modified with conversion to C-array format.
     pub const T5_BASE: (&'static str, &'static str) = (
-        "t5-base/model.ot",
+        "t5-base/model",
         "https://cdn.huggingface.co/t5-base/rust_model.ot",
     );
 }
@@ -46,12 +46,12 @@ impl T5ModelResources {
 impl T5ConfigResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/text-to-text-transfer-transformer.
     pub const T5_SMALL: (&'static str, &'static str) = (
-        "t5-small/config.json",
+        "t5-small/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/t5-small-config.json",
     );
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/text-to-text-transfer-transformer.
     pub const T5_BASE: (&'static str, &'static str) = (
-        "t5-base/config.json",
+        "t5-base/config",
         "https://s3.amazonaws.com/models.huggingface.co/bert/t5-base-config.json",
     );
 }
@@ -59,12 +59,12 @@ impl T5ConfigResources {
 impl T5VocabResources {
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/text-to-text-transfer-transformer.
     pub const T5_SMALL: (&'static str, &'static str) = (
-        "t5-small/spiece.model",
+        "t5-small/spiece",
         "https://s3.amazonaws.com/models.huggingface.co/bert/t5-spiece.model",
     );
     /// Shared under Apache 2.0 license by the Google team at https://github.com/google-research/text-to-text-transfer-transformer.
     pub const T5_BASE: (&'static str, &'static str) = (
-        "t5-base/spiece.model",
+        "t5-base/spiece",
         "https://s3.amazonaws.com/models.huggingface.co/bert/t5-spiece.model",
     );
 }


### PR DESCRIPTION
- Removed extension of the local target (@epwalsh FYI: this is to avoid issues with existing installation, where an existing `config.json` file would prevent the creation of a `config.json` folder)
- Reduced verbosity for the `get_local_path` method, which was now printing on every load (incl. cached)