### PR TITLE
Optional pooling layer in RoBERTa and BERT models

### DIFF
--- a/src/bert/bert_model.rs
+++ b/src/bert/bert_model.rs
@@ -386,7 +386,10 @@ impl<T: BertEmbedding> BertModel<T> {
             train,
         );
 
-        let pooled_output = self.pooler.as_ref().map(|pooler| pooler.forward(&hidden_state));
+        let pooled_output = self
+            .pooler
+            .as_ref()
+            .map(|pooler| pooler.forward(&hidden_state));
 
         Ok(BertModelOutput {
             hidden_state,

--- a/src/bert/bert_model.rs
+++ b/src/bert/bert_model.rs
@@ -124,7 +124,7 @@ impl Config<BertConfig> for BertConfig {}
 pub struct BertModel<T: BertEmbedding> {
     embeddings: T,
     encoder: BertEncoder,
-    pooler: BertPooler,
+    pooler: Option<BertPooler>,
     is_decoder: bool,
 }
 
@@ -162,7 +162,59 @@ impl<T: BertEmbedding> BertModel<T> {
         let is_decoder = config.is_decoder.unwrap_or(false);
         let embeddings = T::new(p / "embeddings", config);
         let encoder = BertEncoder::new(p / "encoder", config);
-        let pooler = BertPooler::new(p / "pooler", config);
+        let pooler = Some(BertPooler::new(p / "pooler", config));
+
+        BertModel {
+            embeddings,
+            encoder,
+            pooler,
+            is_decoder,
+        }
+    }
+
+    /// Build a new `BertModel` with an optional Pooling layer
+    ///
+    /// # Arguments
+    ///
+    /// * `p` - Variable store path for the root of the BERT model
+    /// * `config` - `BertConfig` object defining the model architecture and decoder status
+    /// * `add_pooling_layer` - Enable/Disable an optional pooling layer at the end of the model
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rust_bert::bert::{BertConfig, BertEmbeddings, BertModel};
+    /// use rust_bert::Config;
+    /// use std::path::Path;
+    /// use tch::{nn, Device};
+    ///
+    /// let config_path = Path::new("path/to/config.json");
+    /// let device = Device::Cpu;
+    /// let p = nn::VarStore::new(device);
+    /// let config = BertConfig::from_file(config_path);
+    /// let bert: BertModel<BertEmbeddings> = BertModel::new_with_optional_pooler(&p.root() / "bert", &config, false);
+    /// ```
+    pub fn new_with_optional_pooler<'p, P>(
+        p: P,
+        config: &BertConfig,
+        add_pooling_layer: bool,
+    ) -> BertModel<T>
+    where
+        P: Borrow<nn::Path<'p>>,
+    {
+        let p = p.borrow();
+
+        let is_decoder = config.is_decoder.unwrap_or(false);
+        let embeddings = T::new(p / "embeddings", config);
+        let encoder = BertEncoder::new(p / "encoder", config);
+
+        let pooler = {
+            if add_pooling_layer {
+                Some(BertPooler::new(p / "pooler", config))
+            } else {
+                None
+            }
+        };
 
         BertModel {
             embeddings,
@@ -334,7 +386,7 @@ impl<T: BertEmbedding> BertModel<T> {
             train,
         );
 
-        let pooled_output = self.pooler.forward(&hidden_state);
+        let pooled_output = self.pooler.as_ref().map(|pooler| pooler.forward(&hidden_state));
 
         Ok(BertModelOutput {
             hidden_state,
@@ -682,6 +734,7 @@ impl BertForSequenceClassification {
 
         let logits = base_model_output
             .pooled_output
+            .unwrap()
             .apply_t(&self.dropout, train)
             .apply(&self.classifier);
         BertSequenceClassificationOutput {
@@ -831,6 +884,7 @@ impl BertForMultipleChoice {
 
         let logits = base_model_output
             .pooled_output
+            .unwrap()
             .apply_t(&self.dropout, train)
             .apply(&self.classifier)
             .view((-1, num_choices));
@@ -1132,7 +1186,7 @@ pub struct BertModelOutput {
     /// Last hidden states from the model
     pub hidden_state: Tensor,
     /// Pooled output (hidden state for the first token)
-    pub pooled_output: Tensor,
+    pub pooled_output: Option<Tensor>,
     /// Hidden states for all intermediate layers
     pub all_hidden_states: Option<Vec<Tensor>>,
     /// Attention weights for all intermediate layers

--- a/src/roberta/roberta_model.rs
+++ b/src/roberta/roberta_model.rs
@@ -235,7 +235,7 @@ impl RobertaForMaskedLM {
     {
         let p = p.borrow();
 
-        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let lm_head = RobertaLMHead::new(p / "lm_head", config);
 
         RobertaForMaskedLM { roberta, lm_head }
@@ -416,7 +416,7 @@ impl RobertaForSequenceClassification {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let classifier = RobertaClassificationHead::new(p / "classifier", config);
 
         RobertaForSequenceClassification {
@@ -651,6 +651,7 @@ impl RobertaForMultipleChoice {
 
         let logits = base_model_output
             .pooled_output
+            .unwrap()
             .apply_t(&self.dropout, train)
             .apply(&self.classifier)
             .view((-1, num_choices));
@@ -702,7 +703,7 @@ impl RobertaForTokenClassification {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let num_labels = config
             .id2label
@@ -850,7 +851,7 @@ impl RobertaForQuestionAnswering {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new(p / "roberta", config);
+        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let num_labels = 2;
         let qa_outputs = nn::linear(
             p / "qa_outputs",

--- a/src/roberta/roberta_model.rs
+++ b/src/roberta/roberta_model.rs
@@ -235,7 +235,8 @@ impl RobertaForMaskedLM {
     {
         let p = p.borrow();
 
-        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
+        let roberta =
+            BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let lm_head = RobertaLMHead::new(p / "lm_head", config);
 
         RobertaForMaskedLM { roberta, lm_head }
@@ -416,7 +417,8 @@ impl RobertaForSequenceClassification {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
+        let roberta =
+            BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let classifier = RobertaClassificationHead::new(p / "classifier", config);
 
         RobertaForSequenceClassification {
@@ -703,7 +705,8 @@ impl RobertaForTokenClassification {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
+        let roberta =
+            BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let dropout = Dropout::new(config.hidden_dropout_prob);
         let num_labels = config
             .id2label
@@ -851,7 +854,8 @@ impl RobertaForQuestionAnswering {
         P: Borrow<nn::Path<'p>>,
     {
         let p = p.borrow();
-        let roberta = BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
+        let roberta =
+            BertModel::<RobertaEmbeddings>::new_with_optional_pooler(p / "roberta", config, false);
         let num_labels = 2;
         let qa_outputs = nn::linear(
             p / "qa_outputs",


### PR DESCRIPTION
This PR adds the possibility to enable/disable the last pooling layer in BERT and RoBERTa models.

According to the Hugging Face Transformers source code, all RoBERTa models require no pooling, except for `RobertaForMultipleChoice` which does ([link](https://github.com/huggingface/transformers/blob/master/src/transformers/modeling_roberta.py#L1036)).

Fixes #95 