### PR TITLE
Simplified IO for encoder decoder models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- (BREAKING) Simplified the input and output of encoder/decoder models to avoid needing to take ownership of the possibly cached encoder hidden state, offering a minor performance improvement for text generation tasks. The model output field for encoder hidden states are now optional, and only returned if the encoder hidden states were not provided for the given forward path. This may be a breaking change for low-level dependencies that manipulate directly the encoder/decoder model outputs.
 
 ## [0.12.1] - 2021-01-04
 ### Added

--- a/src/bart/bart_model.rs
+++ b/src/bart/bart_model.rs
@@ -800,9 +800,6 @@ impl LMHeadModel for BartForConditionalGeneration {
     ///   - `lm_logits` - `Tensor` of shape (*batch size*, *sequence_length*, *vocab_size*) representing the logits for each vocab item and position
     ///   - `cache` - `BartCache` made of `Option<Vec<(Option<Vec<&LayerState, &LayerState>>)>>` of length *n_layer* containing the encoder past keys and values for
     ///     both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `encoder_hidden_states` - `Option<Tensor>` Hidden states for the encoder
-    ///   - `all_hidden_states` - None
-    ///   - `all_attentions` - None
     ///
     /// # Example
     ///
@@ -881,8 +878,6 @@ impl LMHeadModel for BartForConditionalGeneration {
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::BARTCache(base_model_output.cache),
-            all_hidden_states: None,
-            all_attentions: None,
         })
     }
 }

--- a/src/bart/bart_model.rs
+++ b/src/bart/bart_model.rs
@@ -340,10 +340,7 @@ impl BartModel {
     ///
     /// * `BartModelOutput` containing:
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *target_sequence_length*, *hidden_size*) representing the activations of the last decoder hidden state
-    ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `(Option<Tensor>, Option<Vec<&LayerState, &LayerState>>)` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///
@@ -500,10 +497,7 @@ impl BartForConditionalGeneration {
     ///
     /// * `BartModelOutput` containing:
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *target_sequence_length*, *vocab_size*) representing the logits for each vocabulary item and position
-    ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `(Option<Tensor>, Option<Vec<&LayerState, &LayerState>>)` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///
@@ -695,10 +689,7 @@ impl BartForSequenceClassification {
     ///
     /// * `BartModelOutput` containing:
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *num_classes*) representing the activations for each class and batch item
-    ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `(Option<Tensor>, Option<Vec<&LayerState, &LayerState>>)` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///

--- a/src/bart/bart_model.rs
+++ b/src/bart/bart_model.rs
@@ -13,7 +13,7 @@
 
 use crate::bart::attention::LayerState;
 use crate::bart::decoder::BartDecoder;
-use crate::bart::encoder::{BartEncoder, BartEncoderOutput};
+use crate::bart::encoder::BartEncoder;
 use crate::common::activations::Activation;
 use crate::common::dropout::Dropout;
 use crate::pipelines::generation_utils::{Cache, LMHeadModel, LMModelOutput};
@@ -386,7 +386,7 @@ impl BartModel {
         input_ids: Option<&Tensor>,
         attention_mask: Option<&Tensor>,
         decoder_input_ids: Option<&Tensor>,
-        encoder_output: Option<BartEncoderOutput>,
+        encoder_output: Option<&Tensor>,
         decoder_attention_mask: Option<&Tensor>,
         layer_states: Option<Vec<(Option<LayerState>, Option<LayerState>)>>,
         train: bool,
@@ -405,21 +405,23 @@ impl BartModel {
                 decoder_attention_mask,
             )
         };
-        let encoder_output = match encoder_output {
-            Some(value) => value,
-            None => {
-                assert!(
-                    input_ids.is_some(),
-                    "input_ids must be provided when encoder output is not pre-computed"
-                );
+
+        let calc_encoder_output = if encoder_output.is_none() {
+            Some(
                 self.encoder
                     .forward_t(input_ids.unwrap(), attention_mask, &self.embeddings, train)
-            }
+                    .hidden_state,
+            )
+        } else {
+            None
         };
+
+        let encoder_output =
+            encoder_output.unwrap_or_else(|| calc_encoder_output.as_ref().unwrap());
 
         let decoder_output = self.decoder.forward_t(
             &decoder_input_ids,
-            &encoder_output.hidden_state,
+            &encoder_output,
             attention_mask,
             decoder_padding_mask.as_ref(),
             causal_mask.as_ref(),
@@ -429,12 +431,9 @@ impl BartModel {
         );
         BartModelOutput {
             decoder_output: decoder_output.hidden_state,
-            encoder_hidden_state: encoder_output.hidden_state,
             cache: decoder_output.next_decoder_cache,
             all_decoder_hidden_states: decoder_output.all_hidden_states,
             all_decoder_attentions: decoder_output.all_attentions,
-            all_encoder_hidden_states: encoder_output.all_hidden_states,
-            all_encoder_attentions: encoder_output.all_attentions,
         }
     }
 }
@@ -543,7 +542,7 @@ impl BartForConditionalGeneration {
         &self,
         input_ids: Option<&Tensor>,
         attention_mask: Option<&Tensor>,
-        encoder_output: Option<BartEncoderOutput>,
+        encoder_output: Option<&Tensor>,
         decoder_input_ids: Option<&Tensor>,
         decoder_attention_mask: Option<&Tensor>,
         old_layer_states: Option<Vec<(Option<LayerState>, Option<LayerState>)>>,
@@ -738,7 +737,7 @@ impl BartForSequenceClassification {
         &self,
         input_ids: &Tensor,
         attention_mask: Option<&Tensor>,
-        encoder_output: Option<BartEncoderOutput>,
+        encoder_output: Option<&Tensor>,
         decoder_input_ids: Option<&Tensor>,
         decoder_attention_mask: Option<&Tensor>,
         train: bool,
@@ -772,12 +771,9 @@ impl BartForSequenceClassification {
             .forward_t(&sentence_representation, train);
         BartModelOutput {
             decoder_output: logits,
-            encoder_hidden_state: base_model_output.encoder_hidden_state,
             cache: None,
             all_decoder_hidden_states: base_model_output.all_decoder_hidden_states,
             all_decoder_attentions: base_model_output.all_decoder_attentions,
-            all_encoder_hidden_states: base_model_output.all_encoder_hidden_states,
-            all_encoder_attentions: base_model_output.all_encoder_attentions,
         }
     }
 }
@@ -857,11 +853,7 @@ impl LMHeadModel for BartForConditionalGeneration {
                 input_ids.as_ref(),
                 attention_mask.as_ref(),
                 decoder_input_ids.as_ref(),
-                Some(BartEncoderOutput {
-                    hidden_state: encoder_outputs.as_ref().unwrap().copy(),
-                    all_hidden_states: None,
-                    all_attentions: None,
-                }),
+                encoder_outputs,
                 None,
                 cached_layer_states,
                 train,
@@ -871,11 +863,7 @@ impl LMHeadModel for BartForConditionalGeneration {
                 input_ids.as_ref(),
                 attention_mask.as_ref(),
                 decoder_input_ids.as_ref(),
-                Some(BartEncoderOutput {
-                    hidden_state: encoder_outputs.as_ref().unwrap().copy(),
-                    all_hidden_states: None,
-                    all_attentions: None,
-                }),
+                encoder_outputs,
                 None,
                 None,
                 train,
@@ -892,7 +880,6 @@ impl LMHeadModel for BartForConditionalGeneration {
             .linear::<Tensor>(&self.base_model.embeddings.ws, None);
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: Some(base_model_output.encoder_hidden_state),
             cache: Cache::BARTCache(base_model_output.cache),
             all_hidden_states: None,
             all_attentions: None,
@@ -907,18 +894,12 @@ pub struct BartModelOutput {
     /// Hidden state of the last layer of the decoder, or logits for a custom head
     /// module after the decoder (e.g. for classification or language modeling tasks)
     pub decoder_output: Tensor,
-    /// Hidden state for the last layer of the encoder
-    pub encoder_hidden_state: Tensor,
     /// Cached outputs of the model (attention layers keys and values) if the model is used for generation
     pub cache: Option<Vec<(Option<LayerState>, Option<LayerState>)>>,
     /// Hidden states for all layers of the decoder
     pub all_decoder_hidden_states: Option<Vec<Tensor>>,
     /// Attention weights for all layers of the decoder
     pub all_decoder_attentions: Option<Vec<Tensor>>,
-    /// Hidden states for all layers of the encoder
-    pub all_encoder_hidden_states: Option<Vec<Tensor>>,
-    /// Attention weights for all layers of the encoder
-    pub all_encoder_attentions: Option<Vec<Tensor>>,
 }
 
 #[cfg(test)]

--- a/src/bart/mod.rs
+++ b/src/bart/mod.rs
@@ -68,5 +68,3 @@ pub use bart_model::{
     BartConfig, BartConfigResources, BartForConditionalGeneration, BartForSequenceClassification,
     BartMergesResources, BartModel, BartModelOutput, BartModelResources, BartVocabResources,
 };
-
-pub(crate) use encoder::BartEncoderOutput;

--- a/src/gpt2/gpt2_model.rs
+++ b/src/gpt2/gpt2_model.rs
@@ -546,9 +546,6 @@ impl LMHeadModel for GPT2LMHeadModel {
     /// * `LMModelOutput` containing:
     ///   - `lm_logits` - `Tensor` of shape (*batch size*, *sequence_length*, *vocab_size*) representing the logits for each vocab item and position
     ///   - `cache` - `Gpt2Cache` made of `Option<Vec<Tensor>>` of length *n_layer* containing the past keys and values of each layer of shape (*2*, *batch size*, *number of heads*, *past_sequence_length*, *hidden size per head*)
-    ///   - `encoder_hidden_states` - None
-    ///   - `all_hidden_states` - `Option<Vec<Tensor>>` of length *num_hidden_layers* with shape (*batch size*, *sequence_length*, *hidden_size*)
-    ///   - `all_attentions` - `Option<Vec<Tensor>>` of length *num_hidden_layers* with shape (*batch size*, *sequence_length*, *hidden_size*)
     ///
     /// # Example
     ///
@@ -643,8 +640,6 @@ impl LMHeadModel for GPT2LMHeadModel {
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::GPT2Cache(base_model_output.cache),
-            all_hidden_states: base_model_output.all_hidden_states,
-            all_attentions: base_model_output.all_attentions,
         })
     }
 }

--- a/src/gpt2/gpt2_model.rs
+++ b/src/gpt2/gpt2_model.rs
@@ -642,7 +642,6 @@ impl LMHeadModel for GPT2LMHeadModel {
         let lm_logits = base_model_output.output.apply(&self.lm_head);
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: None,
             cache: Cache::GPT2Cache(base_model_output.cache),
             all_hidden_states: base_model_output.all_hidden_states,
             all_attentions: base_model_output.all_attentions,

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -405,9 +405,6 @@ impl LMHeadModel for MarianForConditionalGeneration {
     ///   - `lm_logits` - `Tensor` of shape (*batch size*, *sequence_length*, *vocab_size*) representing the logits for each vocab item and position
     ///   - `cache` - `BartCache` made of `Option<Vec<(Option<Vec<&LayerState, &LayerState>>)>>` of length *n_layer* containing the encoder past keys and values for
     ///     both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `encoder_hidden_states` - `Option<Tensor>` Hidden states for the encoder
-    ///   - `all_hidden_states` - None
-    ///   - `all_attentions` - None
     ///
     /// # Example
     ///
@@ -489,8 +486,6 @@ impl LMHeadModel for MarianForConditionalGeneration {
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::BARTCache(base_model_output.cache),
-            all_hidden_states: None,
-            all_attentions: None,
         })
     }
 }

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bart::{BartConfig, BartEncoderOutput, BartModel, BartModelOutput, LayerState};
+use crate::bart::{BartConfig, BartModel, BartModelOutput, LayerState};
 use crate::pipelines::generation_utils::{Cache, LMHeadModel, LMModelOutput};
 use crate::RustBertError;
 use std::borrow::Borrow;
@@ -344,7 +344,7 @@ impl MarianForConditionalGeneration {
         &self,
         input_ids: Option<&Tensor>,
         attention_mask: Option<&Tensor>,
-        encoder_outputs: Option<BartEncoderOutput>,
+        encoder_outputs: Option<&Tensor>,
         decoder_input_ids: Option<&Tensor>,
         decoder_attention_mask: Option<&Tensor>,
         old_layer_states: Option<Vec<(Option<LayerState>, Option<LayerState>)>>,
@@ -461,11 +461,7 @@ impl LMHeadModel for MarianForConditionalGeneration {
                 input_ids.as_ref(),
                 attention_mask.as_ref(),
                 decoder_input_ids.as_ref(),
-                Some(BartEncoderOutput {
-                    hidden_state: encoder_outputs.as_ref().unwrap().copy(),
-                    all_hidden_states: None,
-                    all_attentions: None,
-                }),
+                encoder_outputs,
                 None,
                 cached_layer_states,
                 train,
@@ -474,11 +470,7 @@ impl LMHeadModel for MarianForConditionalGeneration {
                 input_ids.as_ref(),
                 attention_mask.as_ref(),
                 decoder_input_ids.as_ref(),
-                Some(BartEncoderOutput {
-                    hidden_state: encoder_outputs.as_ref().unwrap().copy(),
-                    all_hidden_states: None,
-                    all_attentions: None,
-                }),
+                encoder_outputs,
                 None,
                 None,
                 train,
@@ -496,7 +488,6 @@ impl LMHeadModel for MarianForConditionalGeneration {
             + &self.final_logits_bias;
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: Some(base_model_output.encoder_hidden_state),
             cache: Cache::BARTCache(base_model_output.cache),
             all_hidden_states: None,
             all_attentions: None,

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -298,10 +298,7 @@ impl MarianForConditionalGeneration {
     ///
     /// * `BartModelOutput` containing:
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *target_sequence_length*, *vocab_size*) representing the logits for each vocabulary item and position
-    ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `(Option<Tensor>, Option<Vec<&LayerState, &LayerState>>)` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///

--- a/src/openai_gpt/openai_gpt_model.rs
+++ b/src/openai_gpt/openai_gpt_model.rs
@@ -422,8 +422,6 @@ impl LMHeadModel for OpenAIGPTLMHeadModel {
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::None,
-            all_hidden_states: base_model_output.all_hidden_states,
-            all_attentions: base_model_output.all_attentions,
         })
     }
 }

--- a/src/openai_gpt/openai_gpt_model.rs
+++ b/src/openai_gpt/openai_gpt_model.rs
@@ -421,7 +421,6 @@ impl LMHeadModel for OpenAIGPTLMHeadModel {
         let lm_logits = base_model_output.hidden_state.apply(&self.lm_head);
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: None,
             cache: Cache::None,
             all_hidden_states: base_model_output.all_hidden_states,
             all_attentions: base_model_output.all_attentions,

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -3114,8 +3114,4 @@ pub struct LMModelOutput {
     pub lm_logits: Tensor,
     /// cached state for improved efficiency during decoding
     pub cache: Cache,
-    /// Hidden states for all intermediate model layers
-    pub all_hidden_states: Option<Vec<Tensor>>,
-    /// Attention weights for all intermediate model layers
-    pub all_attentions: Option<Vec<Tensor>>,
 }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -3112,8 +3112,6 @@ pub trait LMHeadModel {
 pub struct LMModelOutput {
     /// Logits for each vocab item and position
     pub lm_logits: Tensor,
-    /// Encoder hidden state (re-used for encoder/decoder architectures)
-    pub encoder_hidden_state: Option<Tensor>,
     /// cached state for improved efficiency during decoding
     pub cache: Cache,
     /// Hidden states for all intermediate model layers

--- a/src/reformer/embeddings.rs
+++ b/src/reformer/embeddings.rs
@@ -276,7 +276,7 @@ impl ReformerEmbeddings {
             None
         };
 
-        let position_ids = position_ids.unwrap_or(calc_position_ids.as_ref().unwrap());
+        let position_ids = position_ids.unwrap_or_else(|| calc_position_ids.as_ref().unwrap());
 
         Ok(self.position_embeddings.forward_t(position_ids, train)
             + input_embeddings.apply_t(&self.dropout, train))

--- a/src/reformer/embeddings.rs
+++ b/src/reformer/embeddings.rs
@@ -276,11 +276,7 @@ impl ReformerEmbeddings {
             None
         };
 
-        let position_ids = if let Some(position_ids) = position_ids {
-            position_ids
-        } else {
-            calc_position_ids.as_ref().unwrap()
-        };
+        let position_ids = position_ids.unwrap_or(calc_position_ids.as_ref().unwrap());
 
         Ok(self.position_embeddings.forward_t(position_ids, train)
             + input_embeddings.apply_t(&self.dropout, train))

--- a/src/reformer/reformer_model.rs
+++ b/src/reformer/reformer_model.rs
@@ -639,8 +639,6 @@ impl LMHeadModel for ReformerModelWithLMHead {
         Ok(LMModelOutput {
             lm_logits: output.logits,
             cache: Cache::ReformerCache(output.next_cache),
-            all_hidden_states: None,
-            all_attentions: None,
         })
     }
 }

--- a/src/reformer/reformer_model.rs
+++ b/src/reformer/reformer_model.rs
@@ -638,7 +638,6 @@ impl LMHeadModel for ReformerModelWithLMHead {
 
         Ok(LMModelOutput {
             lm_logits: output.logits,
-            encoder_hidden_state: None,
             cache: Cache::ReformerCache(output.next_cache),
             all_hidden_states: None,
             all_attentions: None,

--- a/src/t5/t5_model.rs
+++ b/src/t5/t5_model.rs
@@ -644,7 +644,6 @@ impl LMHeadModel for T5ForConditionalGeneration {
 
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: Some(base_model_output.encoder_hidden_state),
             cache: Cache::T5Cache(base_model_output.next_cache),
             all_hidden_states: None,
             all_attentions: None,

--- a/src/t5/t5_model.rs
+++ b/src/t5/t5_model.rs
@@ -255,8 +255,6 @@ impl T5Model {
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *target_sequence_length*, *hidden_size*) representing the activations of the last decoder hidden state
     ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `Option<Vec<(Option<Vec<LayerState, LayerState>>)>>` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///
@@ -433,8 +431,6 @@ impl T5ForConditionalGeneration {
     ///   - `decoder_output` - `Tensor` of shape (*batch size*, *target_sequence_length*, *vocab_size*) representing the logits for each sequence position and vocabulary item
     ///   - `encoder_hidden_states` - `Tensor` of shape (*batch size*, *source_sequence_length*, *hidden_size*) representing the activations of the last encoder hidden state
     ///   - `cache` - `Option<Vec<(Option<Vec<LayerState, LayerState>>)>>` of length *n_layer* containing the encoder padding mask and past keys and values for both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `all_encoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
-    ///   - `all_encoder_attentions` - `Option<Vec<Tensor>>` of length *num_encoder_layers* with shape (*batch size*, *source_sequence_length*, *hidden_size*)
     ///   - `all_decoder_hidden_states` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///   - `all_decoder_attentions` - `Option<Vec<Tensor>>` of length *num_decoder_layers* with shape (*batch size*, *target_sequence_length*, *hidden_size*)
     ///

--- a/src/t5/t5_model.rs
+++ b/src/t5/t5_model.rs
@@ -545,9 +545,6 @@ impl LMHeadModel for T5ForConditionalGeneration {
     ///   - `lm_logits` - `Tensor` of shape (*batch size*, *sequence_length*, *vocab_size*) representing the logits for each vocab item and position
     ///   - `cache` - `T5Cache` made of `Option<Vec<(Option<Vec<&LayerState, &LayerState>>)>>` of length *n_layer* containing the encoder past keys and values for
     ///      both the self attention and the encoder cross attention of each layer of the decoder.
-    ///   - `encoder_hidden_states` - `Option<Tensor>` Hidden states for the encoder
-    ///   - `all_hidden_states` - None
-    ///   - `all_attentions` - None
     ///
     /// # Example
     ///
@@ -645,8 +642,6 @@ impl LMHeadModel for T5ForConditionalGeneration {
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::T5Cache(base_model_output.next_cache),
-            all_hidden_states: None,
-            all_attentions: None,
         })
     }
 }

--- a/src/xlnet/xlnet_model.rs
+++ b/src/xlnet/xlnet_model.rs
@@ -767,7 +767,6 @@ impl XLNetLMHeadModel {
 
         Ok(LMModelOutput {
             lm_logits,
-            encoder_hidden_state: None,
             cache: Cache::XLNetCache(base_model_output.next_cache),
             all_hidden_states,
             all_attentions,

--- a/src/xlnet/xlnet_model.rs
+++ b/src/xlnet/xlnet_model.rs
@@ -743,33 +743,10 @@ impl XLNetLMHeadModel {
         )?;
 
         let lm_logits = base_model_output.hidden_state.apply(&self.lm_head);
-        let all_attentions = if let Some(all_attentions) = base_model_output.all_attentions {
-            Some(
-                all_attentions
-                    .into_iter()
-                    .map(|(u, _)| u)
-                    .collect::<Vec<Tensor>>(),
-            )
-        } else {
-            None
-        };
-        let all_hidden_states = if let Some(all_hidden_states) = base_model_output.all_hidden_states
-        {
-            Some(
-                all_hidden_states
-                    .into_iter()
-                    .map(|(u, _)| u)
-                    .collect::<Vec<Tensor>>(),
-            )
-        } else {
-            None
-        };
 
         Ok(LMModelOutput {
             lm_logits,
             cache: Cache::XLNetCache(base_model_output.next_cache),
-            all_hidden_states,
-            all_attentions,
         })
     }
 }
@@ -793,9 +770,6 @@ impl LMHeadModel for XLNetLMHeadModel {
     /// * `LMModelOutput` containing:
     ///   - `lm_logits` - `Tensor` of shape (*batch size*, *sequence_length*, *vocab_size*) representing the logits for each vocab item and position
     ///   - `cache` - `XLNetCache` made of `Option<Vec<Option<LayerState>>>` of length *n_layers*  and shape (*past_sequence_length*, *batch size*, *hidden_size*) containing the previous content
-    ///   - `encoder_hidden_states` - None
-    ///   - `all_hidden_states` - `Option<Vec<Tensor>>` of length *n_layers* with shape (*batch size*, *sequence_length*, *hidden_size*)
-    ///   - `all_attentions` - `Option<Vec<Tensor>>` of length *n_layers* with shape (*batch size*, *sequence_length*, *hidden_size*)
     ///
     /// # Example
     ///

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -67,7 +67,10 @@ fn bart_lm_model() -> anyhow::Result<()> {
     let model_output =
         bart_model.forward_t(Some(&input_tensor), None, None, None, None, None, false);
     assert_eq!(model_output.decoder_output.size(), vec!(1, 6, 1024));
-    assert_eq!(model_output.encoder_hidden_state.size(), vec!(1, 6, 1024));
+    assert_eq!(
+        model_output.encoder_hidden_state.unwrap().size(),
+        vec!(1, 6, 1024)
+    );
     assert!((model_output.decoder_output.double_value(&[0, 0, 0]) - 0.2610).abs() < 1e-4);
     Ok(())
 }


### PR DESCRIPTION
- Simplified the input and output of encoder/decoder models to avoid needing to take ownership of the possibly cached encoder hidden state
- Encoder hidden states value now optional, and None when the hidden states are provided for the forward pass