### PR TITLE
Fix warning of panic message is not  literal in Rust 2021

### DIFF
--- a/src/pipelines/token_classification.rs
+++ b/src/pipelines/token_classification.rs
@@ -763,10 +763,10 @@ impl TokenClassificationModel {
                 TokenizerOption::XLNet(ref tokenizer) => {
                     Tokenizer::decode(tokenizer, vec![token_id], false, false)
                 }
-                _ => panic!(format!(
+                _ => panic!(
                     "Token classification not implemented for {:?}!",
                     self.tokenizer.model_type()
-                )),
+                ),
             },
             Some(offsets) => {
                 let (start_char, end_char) = (offsets.begin as usize, offsets.end as usize);


### PR DESCRIPTION
This PR fixes a warning for rust 1.50 : 

```
warning: panic message is not a string literal
   --> src/pipelines/token_classification.rs:766:29
    |
766 |                   _ => panic!(format!(
    |  _____________________________^
767 | |                     "Token classification not implemented for {:?}!",
768 | |                     self.tokenizer.model_type()
769 | |                 )),
    | |_________________^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: 1 warning emitted
```
