### PR TITLE
Additional translation models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Addition of translation language pairs: 
+  - English <-> Mandarin
+  - English <-> Cantonese
+  - English <-> Dutch
+  - English <-> Swedish
+  - English <-> Arabic
+  - English <-> Hebrew
+  - English <-> Hindi
+  
+### Changed
+- (BREAKING) Changed `classif_dropout` in `BartConfig` to be an optional field. This affects dependencies instantiating `BartConfig` from scratch, or using `classif_config` for custom model heads.
 
 ## [0.14.0] - 2021-02-22
 ### Added
@@ -44,7 +56,7 @@ All notable changes to this project will be documented in this file. The format 
 - Pre-trained models for DistilRoBERTa, used as a default for integration tests
 
 ### Changed
-- Updated endpoint of the model resources reflecting changs to the Huggingface's model hub
+- Updated endpoint of the model resources reflecting changes to the Hugging Face's model hub
 - Early stopping turned by default on for translation and summarization
 
 ## [0.11.0] - 2020-11-02
@@ -88,7 +100,7 @@ All notable changes to this project will be documented in this file. The format 
 - Addition of the reformer language model and its integration for language generation
 
 ### Changed
-- Changed model resources endpoints to leverage updated Huggingface's model hub
+- Changed model resources endpoints to leverage updated Hugging Face's model hub
 - Updated the beam search processing to use vectorized operations
 
 ## [0.7.11] - 2020-07-26
@@ -157,7 +169,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [0.7.0] - 2020-04-26
 ### Added
 - Addition of Resources for handling file dependencies (e.g. vocabularies, model weights, configurations). Resources may be `LocalResources` (pointing to a filesystem location) or `RemoteResources` (pointing to a remote endpoint). These resources can be passed to a `download_resource` method that returns the location in the local filesystem for both types of resources, downloading them if necessary.
-- Resources specifications for all existing architectures, pointing to model files hosted on Huggingface's model hub.
+- Resources specifications for all existing architectures, pointing to model files hosted on Hugging Face's model hub.
 
 ### Changed
 - (BREAKING) moved the resources' specification to the `GenerateConfig` for `GPT2Generator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 ### Added
 - Addition of translation language pairs: 
-  - English <-> Mandarin
-  - English <-> Cantonese
+  - English <-> Chinese (Simplified)
+  - English <-> Chinese (Traditional)
   - English <-> Dutch
   - English <-> Swedish
   - English <-> Arabic

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Translation using the MarianMT architecture and pre-trained models from the Opus
  - English <-> Catalan
  - English <-> German
  - English <-> Russian
+ - English <-> Mandarin
+ - English <-> Cantonese
+ - English <-> Dutch
+ - English <-> Swedish
  - French <-> German
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Extractive question answering from a given question and context. DistilBERT mode
     let question = String::from("Where does Amy live ?");
     let context = String::from("Amy lives in Amsterdam");
 
-    let answers = qa_model.predict(&vec!(QaInput { question, context }), 1, 32);
+    let answers = qa_model.predict(&[QaInput { question, context }], 1, 32);
 ```
 
 Output:
@@ -68,6 +68,8 @@ Currently supported languages are :
  - English <-> Dutch
  - English <-> Swedish
  - English <-> Arabic
+ - English <-> Hebrew
+ - English <-> Hindi
  - French <-> German
 
 ```rust
@@ -157,7 +159,7 @@ This may impact the results, it is recommended to submit prompts of similar leng
     let input_context_1 = "The dog";
     let input_context_2 = "The cat was";
 
-    let output = model.generate(Some(vec!(input_context_1, input_context_2)), 0, 30, true, false, 
+    let output = model.generate(Some(&[input_context_1, input_context_2]), 0, 30, true, false, 
                                 5, 1.2, 0, 0.9, 1.0, 1.0, 3, 3, None);
 ```
 Example output:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Currently supported languages are :
  - English <-> Catalan
  - English <-> German
  - English <-> Russian
- - English <-> Mandarin
- - English <-> Cantonese
+ - English <-> Chinese (Simplified)
+ - English <-> Chinese (Traditional)
  - English <-> Dutch
  - English <-> Swedish
  - English <-> Arabic

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://docs.rs/rust-bert/badge.svg)](https://docs.rs/rust-bert)
 ![License](https://img.shields.io/crates/l/rust_bert.svg)
 
-Rust native Transformer-based models implementation. Port of Huggingface's [Transformers library](https://github.com/huggingface/transformers), using the [tch-rs](https://github.com/LaurentMazare/tch-rs) crate and pre-processing from [rust-tokenizers](https://github.com/guillaume-be/rust-tokenizers). Supports multithreaded tokenization and GPU inference.
+Rust native Transformer-based models implementation. Port of Hugging Face's [Transformers library](https://github.com/huggingface/transformers), using the [tch-rs](https://github.com/LaurentMazare/tch-rs) crate and pre-processing from [rust-tokenizers](https://github.com/guillaume-be/rust-tokenizers). Supports multi-threaded tokenization and GPU inference.
 This repository exposes the model base architecture, task-specific heads (see below) and [ready-to-use pipelines](#ready-to-use-pipelines). [Benchmarks](#benchmarks) are available at the end of this document.
 
 The following models are currently implemented:
@@ -30,14 +30,14 @@ Longformer|✅|✅|✅| | | |✅|
 
 ## Ready-to-use pipelines
 	
-Based on Huggingface's pipelines, ready to use end-to-end NLP pipelines are available as part of this crate. The following capabilities are currently available:
+Based on Hugging Face's pipelines, ready to use end-to-end NLP pipelines are available as part of this crate. The following capabilities are currently available:
 
 **Disclaimer**
 The contributors of this repository are not responsible for any generation from the 3rd party utilization of the pretrained systems proposed herein.
 
 
 #### 1. Question Answering
-Extractive question answering from a given question and context. DistilBERT model finetuned on SQuAD (Stanford Question Answering Dataset)
+Extractive question answering from a given question and context. DistilBERT model fine-tuned on SQuAD (Stanford Question Answering Dataset)
 
 ```rust
     let qa_model = QuestionAnsweringModel::new(Default::default())?;
@@ -55,7 +55,7 @@ Output:
 
 #### 2. Translation
 Translation using the MarianMT architecture and pre-trained models from the Opus-MT team from Language Technology at the University of Helsinki.
- Currently supported languages are :
+Currently supported languages are :
  - English <-> French
  - English <-> Spanish
  - English <-> Portuguese
@@ -67,6 +67,7 @@ Translation using the MarianMT architecture and pre-trained models from the Opus
  - English <-> Cantonese
  - English <-> Dutch
  - English <-> Swedish
+ - English <-> Arabic
  - French <-> German
 
 ```rust
@@ -148,7 +149,7 @@ Example output:
 Generate language based on a prompt. GPT2 and GPT available as base models.
 Include techniques such as beam search, top-k and nucleus sampling, temperature setting and repetition penalty.
 Supports batch generation of sentences from several prompts. Sequences will be left-padded with the model's padding token if present, the unknown token otherwise.
-This may impact the results and it is recommended to submit prompts of similar length for best results
+This may impact the results, it is recommended to submit prompts of similar length for best results
 
 ```rust
     let model = GPT2Generator::new(Default::default())?;
@@ -197,7 +198,7 @@ Output:
 ```
 
 #### 7. Sentiment analysis
-Predicts the binary sentiment for a sentence. DistilBERT model finetuned on SST-2.
+Predicts the binary sentiment for a sentence. DistilBERT model fine-tuned on SST-2.
 ```rust
     let sentiment_classifier = SentimentModel::new(Default::default())?;
                                                         
@@ -221,7 +222,7 @@ Output:
 ```
 
 #### 8. Named Entity Recognition
-Extracts entities (Person, Location, Organization, Miscellaneous) from text. BERT cased large model finetuned on CoNNL03, contributed by the [MDZ Digital Library team at the Bavarian State Library](https://github.com/dbmdz).
+Extracts entities (Person, Location, Organization, Miscellaneous) from text. BERT cased large model fine-tuned on CoNNL03, contributed by the [MDZ Digital Library team at the Bavarian State Library](https://github.com/dbmdz).
 Models are currently available for English, German, Spanish and Dutch.
 ```rust
     let ner_model = NERModel::new(default::default())?;
@@ -258,7 +259,7 @@ If this quality check is to be skipped, an alternative method `load_partial` can
 
 ## Setup
 
-A number of pretrained model configuration, weights and vocabulary are downloaded directly from [Huggingface's model repository](https://huggingface.co/models).
+A number of pretrained model configuration, weights and vocabulary are downloaded directly from [Hugging Face's model repository](https://huggingface.co/models).
 The list of models available with Rust-compatible weights is available at [https://huggingface.co/models?filter=rust](https://huggingface.co/models?filter=rust).
 The models will be downloaded to the environment variable `RUSTBERT_CACHE` if it exists, otherwise to `~/.cache/.rustbert`.
 Additional models can be added if of interest, please raise an issue.
@@ -269,7 +270,7 @@ Several Python scripts to load Pytorch weights and convert them to the appropria
 1. Compile the package: `cargo build`
 2. Download the model files & perform necessary conversions
    - Set-up a virtual environment and install dependencies
-   - Download the Pytorch model of interest (`pytorch_model.bin` from [Huggingface's model repository](https://huggingface.co/models))
+   - Download the Pytorch model of interest (`pytorch_model.bin` from [Hugging Face's model repository](https://huggingface.co/models))
    - run the conversion script `python /utils/convert_model.py <PATH_TO_PYTORCH_WEIGHTS>`.
    
 ## Citation

--- a/src/bart/bart_model.rs
+++ b/src/bart/bart_model.rs
@@ -189,7 +189,7 @@ pub struct BartConfig {
     pub activation_function: Option<Activation>,
     pub activation_dropout: f64,
     pub attention_dropout: f64,
-    pub classif_dropout: f64,
+    pub classif_dropout: Option<f64>,
     pub d_model: i64,
     pub decoder_attention_heads: i64,
     pub decoder_ffn_dim: i64,
@@ -629,7 +629,7 @@ impl BartClassificationHead {
             config.d_model,
             Default::default(),
         );
-        let dropout = Dropout::new(config.classif_dropout);
+        let dropout = Dropout::new(config.classif_dropout.unwrap_or(0.0));
         let out_proj = nn::linear(
             p / "out_proj",
             config.d_model,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! let question = String::from("Where does Amy live ?");
 //! let context = String::from("Amy lives in Amsterdam");
-//! let answers = qa_model.predict(&vec![QaInput { question, context }], 1, 32);
+//! let answers = qa_model.predict(&[QaInput { question, context }], 1, 32);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -112,6 +112,16 @@ impl MarianModelResources {
         "marian-mt-sv-en/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/rust_model.ot",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ARABIC2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-ar-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-ar-en/resolve/main/rust_model.ot",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ENGLISH2ARABIC: (&'static str, &'static str) = (
+        "marian-mt-en-ar/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -184,6 +194,16 @@ impl MarianConfigResources {
     pub const SWEDISH2ENGLISH: (&'static str, &'static str) = (
         "marian-mt-sv-en/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ARABIC2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-ar-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-ar-en/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2ARABIC: (&'static str, &'static str) = (
+        "marian-mt-en-ar/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/config.json",
     );
 }
 
@@ -258,6 +278,16 @@ impl MarianVocabResources {
         "marian-mt-sv-en/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/vocab.json",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ARABIC2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-ar-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-ar-en/resolve/main/vocab.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2ARABIC: (&'static str, &'static str) = (
+        "marian-mt-en-ar/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -331,6 +361,16 @@ impl MarianSpmResources {
         "marian-mt-sv-en/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/source.spm",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ARABIC2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-ar-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-ar-en/resolve/main/source.spm",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2ARABIC: (&'static str, &'static str) = (
+        "marian-mt-en-ar/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -346,6 +386,7 @@ impl MarianPrefix {
     pub const ENGLISH2GERMAN: Option<&'static str> = None;
     pub const ENGLISH2RUSSIAN: Option<&'static str> = None;
     pub const ENGLISH2SWEDISH: Option<&'static str> = None;
+    pub const ENGLISH2ARABIC: Option<&'static str> = Some(">>ara<< ");
     pub const FRENCH2ENGLISH: Option<&'static str> = None;
     pub const CATALAN2ENGLISH: Option<&'static str> = None;
     pub const SPANISH2ENGLISH: Option<&'static str> = None;
@@ -359,6 +400,7 @@ impl MarianPrefix {
     pub const DUTCH2ENGLISH: Option<&'static str> = None;
     pub const CHINESE2ENGLISH: Option<&'static str> = None;
     pub const SWEDISH2ENGLISH: Option<&'static str> = None;
+    pub const ARABIC2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -102,6 +102,16 @@ impl MarianModelResources {
         "marian-mt-zh-en/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en/resolve/main/rust_model.ot",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ENGLISH2SWEDISH: (&'static str, &'static str) = (
+        "marian-mt-en-sv/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-sv/resolve/main/rust_model.ot",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const SWEDISH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-sv-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -164,6 +174,16 @@ impl MarianConfigResources {
     pub const ENGLISH2CHINESE: (&'static str, &'static str) = (
         "marian-mt-en-zh/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2SWEDISH: (&'static str, &'static str) = (
+        "marian-mt-en-sv/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-sv/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const SWEDISH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-sv-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/config.json",
     );
 }
 
@@ -228,6 +248,16 @@ impl MarianVocabResources {
         "marian-mt-en-zh/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/vocab.json",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2SWEDISH: (&'static str, &'static str) = (
+        "marian-mt-en-sv/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-sv/resolve/main/vocab.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const SWEDISH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-sv-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -291,6 +321,16 @@ impl MarianSpmResources {
         "marian-mt-en-zh/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/source.spm",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2SWEDISH: (&'static str, &'static str) = (
+        "marian-mt-en-sv/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-sv/resolve/main/source.spm",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const SWEDISH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-sv-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-sv-en/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -300,10 +340,12 @@ impl MarianPrefix {
     pub const ENGLISH2PORTUGUESE: Option<&'static str> = Some(">>pt<< ");
     pub const ENGLISH2ITALIAN: Option<&'static str> = Some(">>it<< ");
     pub const ENGLISH2ROMANIAN: Option<&'static str> = Some(">>ro<< ");
+    pub const ENGLISH2DUTCH: Option<&'static str> = None;
     pub const ENGLISH2MANDARIN: Option<&'static str> = Some(">>cmn_Hant<< ");
     pub const ENGLISH2CANTONESE: Option<&'static str> = Some(">>yue_Hant<< ");
     pub const ENGLISH2GERMAN: Option<&'static str> = None;
     pub const ENGLISH2RUSSIAN: Option<&'static str> = None;
+    pub const ENGLISH2SWEDISH: Option<&'static str> = None;
     pub const FRENCH2ENGLISH: Option<&'static str> = None;
     pub const CATALAN2ENGLISH: Option<&'static str> = None;
     pub const SPANISH2ENGLISH: Option<&'static str> = None;
@@ -314,9 +356,9 @@ impl MarianPrefix {
     pub const RUSSIAN2ENGLISH: Option<&'static str> = None;
     pub const FRENCH2GERMAN: Option<&'static str> = None;
     pub const GERMAN2FRENCH: Option<&'static str> = None;
-    pub const ENGLISH2DUTCH: Option<&'static str> = None;
     pub const DUTCH2ENGLISH: Option<&'static str> = None;
     pub const CHINESE2ENGLISH: Option<&'static str> = None;
+    pub const SWEDISH2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -132,6 +132,16 @@ impl MarianModelResources {
         "marian-mt-en-hi/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/rust_model.ot",
     );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-he-en. Modified with conversion to C-array format.
+    pub const HEBREW2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-he-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-he-en/resolve/main/rust_model.ot",
+    );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-en-he. Modified with conversion to C-array format.
+    pub const ENGLISH2HEBREW: (&'static str, &'static str) = (
+        "marian-mt-en-he/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-he/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -224,6 +234,16 @@ impl MarianConfigResources {
     pub const ENGLISH2HINDI: (&'static str, &'static str) = (
         "marian-mt-en-hi/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/config.json",
+    );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-he-en. Modified with conversion to C-array format.
+    pub const HEBREW2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-he-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-he-en/resolve/main/config.json",
+    );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-en-he. Modified with conversion to C-array format.
+    pub const ENGLISH2HEBREW: (&'static str, &'static str) = (
+        "marian-mt-en-he/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-he/resolve/main/config.json",
     );
 }
 
@@ -318,6 +338,16 @@ impl MarianVocabResources {
         "marian-mt-en-hi/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/vocab.json",
     );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-he-en. Modified with conversion to C-array format.
+    pub const HEBREW2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-he-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-he-en/resolve/main/vocab.json",
+    );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-en-he. Modified with conversion to C-array format.
+    pub const ENGLISH2HEBREW: (&'static str, &'static str) = (
+        "marian-mt-en-he/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-he/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -411,6 +441,16 @@ impl MarianSpmResources {
         "marian-mt-en-hi/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/source.spm",
     );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-he-en. Modified with conversion to C-array format.
+    pub const HEBREW2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-he-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-he-en/resolve/main/source.spm",
+    );
+    /// Shared under Apache 2.0 License license at https://huggingface.co/tiedeman/opus-mt-en-he. Modified with conversion to C-array format.
+    pub const ENGLISH2HEBREW: (&'static str, &'static str) = (
+        "marian-mt-en-he/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-he/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -428,6 +468,7 @@ impl MarianPrefix {
     pub const ENGLISH2SWEDISH: Option<&'static str> = None;
     pub const ENGLISH2ARABIC: Option<&'static str> = Some(">>ara<< ");
     pub const ENGLISH2HINDI: Option<&'static str> = None;
+    pub const ENGLISH2HEBREW: Option<&'static str> = None;
     pub const FRENCH2ENGLISH: Option<&'static str> = None;
     pub const CATALAN2ENGLISH: Option<&'static str> = None;
     pub const SPANISH2ENGLISH: Option<&'static str> = None;
@@ -443,6 +484,7 @@ impl MarianPrefix {
     pub const SWEDISH2ENGLISH: Option<&'static str> = None;
     pub const ARABIC2ENGLISH: Option<&'static str> = None;
     pub const HINDI2ENGLISH: Option<&'static str> = None;
+    pub const HEBREW2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -461,8 +461,8 @@ impl MarianPrefix {
     pub const ENGLISH2ITALIAN: Option<&'static str> = Some(">>it<< ");
     pub const ENGLISH2ROMANIAN: Option<&'static str> = Some(">>ro<< ");
     pub const ENGLISH2DUTCH: Option<&'static str> = None;
-    pub const ENGLISH2MANDARIN: Option<&'static str> = Some(">>cmn_Hant<< ");
-    pub const ENGLISH2CANTONESE: Option<&'static str> = Some(">>yue_Hant<< ");
+    pub const ENGLISH2CHINESE_SIMPLIFIED: Option<&'static str> = Some(">>cmn_Hans<< ");
+    pub const ENGLISH2CHINESE_TRADITIONAL: Option<&'static str> = Some(">>cmn_Hant<< ");
     pub const ENGLISH2GERMAN: Option<&'static str> = None;
     pub const ENGLISH2RUSSIAN: Option<&'static str> = None;
     pub const ENGLISH2SWEDISH: Option<&'static str> = None;

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -82,6 +82,16 @@ impl MarianModelResources {
         "marian-mt-de-fr/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr/resolve/main/rust_model.ot",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ENGLISH2DUTCH: (&'static str, &'static str) = (
+        "marian-mt-en-nl/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-nl/resolve/main/rust_model.ot",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const DUTCH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-nl-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -124,6 +134,16 @@ impl MarianConfigResources {
     pub const GERMAN2FRENCH: (&'static str, &'static str) = (
         "marian-mt-de-fr/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2DUTCH: (&'static str, &'static str) = (
+        "marian-mt-en-nl/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-nl/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const DUTCH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-nl-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/config.json",
     );
 }
 
@@ -168,6 +188,16 @@ impl MarianVocabResources {
         "marian-mt-de-fr/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr/resolve/main/vocab.json",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2DUTCH: (&'static str, &'static str) = (
+        "marian-mt-en-nl/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-nl/resolve/main/vocab.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const DUTCH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-nl-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -211,6 +241,16 @@ impl MarianSpmResources {
         "marian-mt-de-fr/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr/resolve/main/source.spm",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2DUTCH: (&'static str, &'static str) = (
+        "marian-mt-en-nl/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-nl/resolve/main/source.spm",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const DUTCH2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-nl-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -232,6 +272,8 @@ impl MarianPrefix {
     pub const RUSSIAN2ENGLISH: Option<&'static str> = None;
     pub const FRENCH2GERMAN: Option<&'static str> = None;
     pub const GERMAN2FRENCH: Option<&'static str> = None;
+    pub const ENGLISH2DUTCH: Option<&'static str> = None;
+    pub const DUTCH2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -122,6 +122,16 @@ impl MarianModelResources {
         "marian-mt-en-ar/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/rust_model.ot",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const HINDI2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-hi-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-hi-en/resolve/main/rust_model.ot",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ENGLISH2HINDI: (&'static str, &'static str) = (
+        "marian-mt-en-hi/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -204,6 +214,16 @@ impl MarianConfigResources {
     pub const ENGLISH2ARABIC: (&'static str, &'static str) = (
         "marian-mt-en-ar/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const HINDI2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-hi-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-hi-en/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2HINDI: (&'static str, &'static str) = (
+        "marian-mt-en-hi/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/config.json",
     );
 }
 
@@ -288,6 +308,16 @@ impl MarianVocabResources {
         "marian-mt-en-ar/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/vocab.json",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const HINDI2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-hi-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-hi-en/resolve/main/vocab.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2HINDI: (&'static str, &'static str) = (
+        "marian-mt-en-hi/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -371,6 +401,16 @@ impl MarianSpmResources {
         "marian-mt-en-ar/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar/resolve/main/source.spm",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const HINDI2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-hi-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-hi-en/resolve/main/source.spm",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2HINDI: (&'static str, &'static str) = (
+        "marian-mt-en-hi/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-hi/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -387,6 +427,7 @@ impl MarianPrefix {
     pub const ENGLISH2RUSSIAN: Option<&'static str> = None;
     pub const ENGLISH2SWEDISH: Option<&'static str> = None;
     pub const ENGLISH2ARABIC: Option<&'static str> = Some(">>ara<< ");
+    pub const ENGLISH2HINDI: Option<&'static str> = None;
     pub const FRENCH2ENGLISH: Option<&'static str> = None;
     pub const CATALAN2ENGLISH: Option<&'static str> = None;
     pub const SPANISH2ENGLISH: Option<&'static str> = None;
@@ -401,6 +442,7 @@ impl MarianPrefix {
     pub const CHINESE2ENGLISH: Option<&'static str> = None;
     pub const SWEDISH2ENGLISH: Option<&'static str> = None;
     pub const ARABIC2ENGLISH: Option<&'static str> = None;
+    pub const HINDI2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/marian/marian_model.rs
+++ b/src/marian/marian_model.rs
@@ -92,6 +92,16 @@ impl MarianModelResources {
         "marian-mt-nl-en/model",
         "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/rust_model.ot",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const ENGLISH2CHINESE: (&'static str, &'static str) = (
+        "marian-mt-en-zh/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/rust_model.ot",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT. Modified with conversion to C-array format.
+    pub const CHINESE2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-zh-en/model",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en/resolve/main/rust_model.ot",
+    );
 }
 
 impl MarianConfigResources {
@@ -144,6 +154,16 @@ impl MarianConfigResources {
     pub const DUTCH2ENGLISH: (&'static str, &'static str) = (
         "marian-mt-nl-en/config",
         "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const CHINESE2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-zh-en/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en/resolve/main/config.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2CHINESE: (&'static str, &'static str) = (
+        "marian-mt-en-zh/config",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/config.json",
     );
 }
 
@@ -198,6 +218,16 @@ impl MarianVocabResources {
         "marian-mt-nl-en/vocab",
         "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/vocab.json",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const CHINESE2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-zh-en/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en/resolve/main/vocab.json",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2CHINESE: (&'static str, &'static str) = (
+        "marian-mt-en-zh/vocab",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/vocab.json",
+    );
 }
 
 impl MarianSpmResources {
@@ -251,6 +281,16 @@ impl MarianSpmResources {
         "marian-mt-nl-en/spiece",
         "https://huggingface.co/Helsinki-NLP/opus-mt-nl-en/resolve/main/source.spm",
     );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const CHINESE2ENGLISH: (&'static str, &'static str) = (
+        "marian-mt-zh-en/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en/resolve/main/source.spm",
+    );
+    /// Shared under Creative Commons Attribution 4.0 International License license by the Opus-MT team from Language Technology at the University of Helsinki at https://github.com/Helsinki-NLP/Opus-MT.
+    pub const ENGLISH2CHINESE: (&'static str, &'static str) = (
+        "marian-mt-en-zh/spiece",
+        "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh/resolve/main/source.spm",
+    );
 }
 
 impl MarianPrefix {
@@ -260,6 +300,8 @@ impl MarianPrefix {
     pub const ENGLISH2PORTUGUESE: Option<&'static str> = Some(">>pt<< ");
     pub const ENGLISH2ITALIAN: Option<&'static str> = Some(">>it<< ");
     pub const ENGLISH2ROMANIAN: Option<&'static str> = Some(">>ro<< ");
+    pub const ENGLISH2MANDARIN: Option<&'static str> = Some(">>cmn_Hant<< ");
+    pub const ENGLISH2CANTONESE: Option<&'static str> = Some(">>yue_Hant<< ");
     pub const ENGLISH2GERMAN: Option<&'static str> = None;
     pub const ENGLISH2RUSSIAN: Option<&'static str> = None;
     pub const FRENCH2ENGLISH: Option<&'static str> = None;
@@ -274,6 +316,7 @@ impl MarianPrefix {
     pub const GERMAN2FRENCH: Option<&'static str> = None;
     pub const ENGLISH2DUTCH: Option<&'static str> = None;
     pub const DUTCH2ENGLISH: Option<&'static str> = None;
+    pub const CHINESE2ENGLISH: Option<&'static str> = None;
 }
 
 /// # Marian Model for conditional generation

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -44,8 +44,8 @@
 //! - English <-> Catalan
 //! - English <-> German
 //! - English <-> Russian
-//! - English <-> Mandarin
-//! - English <-> Cantonese
+//! - English <-> Chinese (Simplified)
+//! - English <-> Chinese (Traditional)
 //! - English <-> Dutch
 //! - English <-> Swedish
 //! - English <-> Arabic

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -16,7 +16,7 @@
 //! let question = String::from("Where does Amy live ?");
 //! let context = String::from("Amy lives in Amsterdam");
 //!
-//! let answers = qa_model.predict(&vec![QaInput { question, context }], 1, 32);
+//! let answers = qa_model.predict(&[QaInput { question, context }], 1, 32);
 //! # Ok(())
 //! # }
 //! ```
@@ -49,6 +49,8 @@
 //! - English <-> Dutch
 //! - English <-> Swedish
 //! - English <-> Arabic
+//! - English <-> Hebrew
+//! - English <-> Hindi
 //! - French <-> German
 //!
 //! ```no_run

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -48,6 +48,7 @@
 //! - English <-> Cantonese
 //! - English <-> Dutch
 //! - English <-> Swedish
+//! - English <-> Arabic
 //! - French <-> German
 //!
 //! ```no_run

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -44,7 +44,12 @@
 //! - English <-> Catalan
 //! - English <-> German
 //! - English <-> Russian
+//! - English <-> Mandarin
+//! - English <-> Cantonese
+//! - English <-> Dutch
+//! - English <-> Swedish
 //! - French <-> German
+//!
 //! ```no_run
 //! # fn main() -> anyhow::Result<()> {
 //! # use rust_bert::pipelines::generation_utils::LanguageGenerator;

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -80,6 +80,7 @@ pub enum Language {
     ChineseToEnglish,
     SwedishToEnglish,
     ArabicToEnglish,
+    HindiToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -93,6 +94,7 @@ pub enum Language {
     EnglishToCantonese,
     EnglishToSwedish,
     EnglishToArabic,
+    EnglishToHindi,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -341,6 +343,22 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::ARABIC2ENGLISH,
         model_type: ModelType::Marian,
     };
+    pub const ENGLISH2HINDI: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2HINDI,
+        config_resource: MarianConfigResources::ENGLISH2HINDI,
+        vocab_resource: MarianVocabResources::ENGLISH2HINDI,
+        merges_resource: MarianSpmResources::ENGLISH2HINDI,
+        prefix: MarianPrefix::ENGLISH2HINDI,
+        model_type: ModelType::Marian,
+    };
+    pub const HINDI2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::HINDI2ENGLISH,
+        config_resource: MarianConfigResources::HINDI2ENGLISH,
+        vocab_resource: MarianVocabResources::HINDI2ENGLISH,
+        merges_resource: MarianSpmResources::HINDI2ENGLISH,
+        prefix: MarianPrefix::HINDI2ENGLISH,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -426,6 +444,7 @@ impl TranslationConfig {
             Language::EnglishToCantonese => RemoteTranslationResources::ENGLISH2CANTONESE,
             Language::EnglishToSwedish => RemoteTranslationResources::ENGLISH2SWEDISH,
             Language::EnglishToArabic => RemoteTranslationResources::ENGLISH2ARABIC,
+            Language::EnglishToHindi => RemoteTranslationResources::ENGLISH2HINDI,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -439,6 +458,7 @@ impl TranslationConfig {
             Language::ChineseToEnglish => RemoteTranslationResources::CHINESE2ENGLISH,
             Language::SwedishToEnglish => RemoteTranslationResources::SWEDISH2ENGLISH,
             Language::ArabicToEnglish => RemoteTranslationResources::ARABIC2ENGLISH,
+            Language::HindiToEnglish => RemoteTranslationResources::HINDI2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -81,6 +81,7 @@ pub enum Language {
     SwedishToEnglish,
     ArabicToEnglish,
     HindiToEnglish,
+    HebrewToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -95,6 +96,7 @@ pub enum Language {
     EnglishToSwedish,
     EnglishToArabic,
     EnglishToHindi,
+    EnglishToHebrew,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -359,6 +361,22 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::HINDI2ENGLISH,
         model_type: ModelType::Marian,
     };
+    pub const ENGLISH2HEBREW: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2HEBREW,
+        config_resource: MarianConfigResources::ENGLISH2HEBREW,
+        vocab_resource: MarianVocabResources::ENGLISH2HEBREW,
+        merges_resource: MarianSpmResources::ENGLISH2HEBREW,
+        prefix: MarianPrefix::ENGLISH2HEBREW,
+        model_type: ModelType::Marian,
+    };
+    pub const HEBREW2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::HEBREW2ENGLISH,
+        config_resource: MarianConfigResources::HEBREW2ENGLISH,
+        vocab_resource: MarianVocabResources::HEBREW2ENGLISH,
+        merges_resource: MarianSpmResources::HEBREW2ENGLISH,
+        prefix: MarianPrefix::HEBREW2ENGLISH,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -445,6 +463,7 @@ impl TranslationConfig {
             Language::EnglishToSwedish => RemoteTranslationResources::ENGLISH2SWEDISH,
             Language::EnglishToArabic => RemoteTranslationResources::ENGLISH2ARABIC,
             Language::EnglishToHindi => RemoteTranslationResources::ENGLISH2HINDI,
+            Language::EnglishToHebrew => RemoteTranslationResources::ENGLISH2HEBREW,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -459,6 +478,7 @@ impl TranslationConfig {
             Language::SwedishToEnglish => RemoteTranslationResources::SWEDISH2ENGLISH,
             Language::ArabicToEnglish => RemoteTranslationResources::ARABIC2ENGLISH,
             Language::HindiToEnglish => RemoteTranslationResources::HINDI2ENGLISH,
+            Language::HebrewToEnglish => RemoteTranslationResources::HEBREW2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -76,6 +76,7 @@ pub enum Language {
     RomanianToEnglish,
     GermanToEnglish,
     RussianToEnglish,
+    DutchToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -84,6 +85,7 @@ pub enum Language {
     EnglishToRomanian,
     EnglishToGerman,
     EnglishToRussian,
+    EnglishToDutch,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -260,6 +262,22 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::GERMAN2FRENCH,
         model_type: ModelType::Marian,
     };
+    pub const ENGLISH2DUTCH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2DUTCH,
+        config_resource: MarianConfigResources::ENGLISH2DUTCH,
+        vocab_resource: MarianVocabResources::ENGLISH2DUTCH,
+        merges_resource: MarianSpmResources::ENGLISH2DUTCH,
+        prefix: MarianPrefix::ENGLISH2DUTCH,
+        model_type: ModelType::Marian,
+    };
+    pub const DUTCH2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::DUTCH2ENGLISH,
+        config_resource: MarianConfigResources::DUTCH2ENGLISH,
+        vocab_resource: MarianVocabResources::DUTCH2ENGLISH,
+        merges_resource: MarianSpmResources::DUTCH2ENGLISH,
+        prefix: MarianPrefix::DUTCH2ENGLISH,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -340,6 +358,7 @@ impl TranslationConfig {
             Language::EnglishToRomanian => RemoteTranslationResources::ENGLISH2ROMANIAN,
             Language::EnglishToGerman => RemoteTranslationResources::ENGLISH2GERMAN,
             Language::EnglishToRussian => RemoteTranslationResources::ENGLISH2RUSSIAN,
+            Language::EnglishToDutch => RemoteTranslationResources::ENGLISH2DUTCH,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -349,6 +368,7 @@ impl TranslationConfig {
             Language::RomanianToEnglish => RemoteTranslationResources::ROMANIAN2ENGLISH,
             Language::GermanToEnglish => RemoteTranslationResources::GERMAN2ENGLISH,
             Language::RussianToEnglish => RemoteTranslationResources::RUSSIAN2ENGLISH,
+            Language::DutchToEnglish => RemoteTranslationResources::DUTCH2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -78,6 +78,7 @@ pub enum Language {
     RussianToEnglish,
     DutchToEnglish,
     ChineseToEnglish,
+    SwedishToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -89,6 +90,7 @@ pub enum Language {
     EnglishToDutch,
     EnglishToMandarin,
     EnglishToCantonese,
+    EnglishToSwedish,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -305,6 +307,22 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::ENGLISH2CANTONESE,
         model_type: ModelType::Marian,
     };
+    pub const ENGLISH2SWEDISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2SWEDISH,
+        config_resource: MarianConfigResources::ENGLISH2SWEDISH,
+        vocab_resource: MarianVocabResources::ENGLISH2SWEDISH,
+        merges_resource: MarianSpmResources::ENGLISH2SWEDISH,
+        prefix: MarianPrefix::ENGLISH2SWEDISH,
+        model_type: ModelType::Marian,
+    };
+    pub const SWEDISH2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::SWEDISH2ENGLISH,
+        config_resource: MarianConfigResources::SWEDISH2ENGLISH,
+        vocab_resource: MarianVocabResources::SWEDISH2ENGLISH,
+        merges_resource: MarianSpmResources::SWEDISH2ENGLISH,
+        prefix: MarianPrefix::SWEDISH2ENGLISH,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -388,6 +406,7 @@ impl TranslationConfig {
             Language::EnglishToDutch => RemoteTranslationResources::ENGLISH2DUTCH,
             Language::EnglishToMandarin => RemoteTranslationResources::ENGLISH2MANDARIN,
             Language::EnglishToCantonese => RemoteTranslationResources::ENGLISH2CANTONESE,
+            Language::EnglishToSwedish => RemoteTranslationResources::ENGLISH2SWEDISH,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -399,6 +418,7 @@ impl TranslationConfig {
             Language::RussianToEnglish => RemoteTranslationResources::RUSSIAN2ENGLISH,
             Language::DutchToEnglish => RemoteTranslationResources::DUTCH2ENGLISH,
             Language::ChineseToEnglish => RemoteTranslationResources::CHINESE2ENGLISH,
+            Language::SwedishToEnglish => RemoteTranslationResources::SWEDISH2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -79,6 +79,7 @@ pub enum Language {
     DutchToEnglish,
     ChineseToEnglish,
     SwedishToEnglish,
+    ArabicToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -91,6 +92,7 @@ pub enum Language {
     EnglishToMandarin,
     EnglishToCantonese,
     EnglishToSwedish,
+    EnglishToArabic,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -323,6 +325,22 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::SWEDISH2ENGLISH,
         model_type: ModelType::Marian,
     };
+    pub const ENGLISH2ARABIC: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2ARABIC,
+        config_resource: MarianConfigResources::ENGLISH2ARABIC,
+        vocab_resource: MarianVocabResources::ENGLISH2ARABIC,
+        merges_resource: MarianSpmResources::ENGLISH2ARABIC,
+        prefix: MarianPrefix::ENGLISH2ARABIC,
+        model_type: ModelType::Marian,
+    };
+    pub const ARABIC2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ARABIC2ENGLISH,
+        config_resource: MarianConfigResources::ARABIC2ENGLISH,
+        vocab_resource: MarianVocabResources::ARABIC2ENGLISH,
+        merges_resource: MarianSpmResources::ARABIC2ENGLISH,
+        prefix: MarianPrefix::ARABIC2ENGLISH,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -407,6 +425,7 @@ impl TranslationConfig {
             Language::EnglishToMandarin => RemoteTranslationResources::ENGLISH2MANDARIN,
             Language::EnglishToCantonese => RemoteTranslationResources::ENGLISH2CANTONESE,
             Language::EnglishToSwedish => RemoteTranslationResources::ENGLISH2SWEDISH,
+            Language::EnglishToArabic => RemoteTranslationResources::ENGLISH2ARABIC,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -419,6 +438,7 @@ impl TranslationConfig {
             Language::DutchToEnglish => RemoteTranslationResources::DUTCH2ENGLISH,
             Language::ChineseToEnglish => RemoteTranslationResources::CHINESE2ENGLISH,
             Language::SwedishToEnglish => RemoteTranslationResources::SWEDISH2ENGLISH,
+            Language::ArabicToEnglish => RemoteTranslationResources::ARABIC2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -91,8 +91,8 @@ pub enum Language {
     EnglishToGerman,
     EnglishToRussian,
     EnglishToDutch,
-    EnglishToMandarin,
-    EnglishToCantonese,
+    EnglishToChineseSimplified,
+    EnglishToChineseTraditional,
     EnglishToSwedish,
     EnglishToArabic,
     EnglishToHindi,
@@ -297,20 +297,20 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::CHINESE2ENGLISH,
         model_type: ModelType::Marian,
     };
-    pub const ENGLISH2MANDARIN: RemoteTranslationResources = Self {
+    pub const ENGLISH2CHINESE_SIMPLIFIED: RemoteTranslationResources = Self {
         model_resource: MarianModelResources::ENGLISH2CHINESE,
         config_resource: MarianConfigResources::ENGLISH2CHINESE,
         vocab_resource: MarianVocabResources::ENGLISH2CHINESE,
         merges_resource: MarianSpmResources::ENGLISH2CHINESE,
-        prefix: MarianPrefix::ENGLISH2MANDARIN,
+        prefix: MarianPrefix::ENGLISH2CHINESE_SIMPLIFIED,
         model_type: ModelType::Marian,
     };
-    pub const ENGLISH2CANTONESE: RemoteTranslationResources = Self {
+    pub const ENGLISH2CHINESE_TRADITIONAL: RemoteTranslationResources = Self {
         model_resource: MarianModelResources::ENGLISH2CHINESE,
         config_resource: MarianConfigResources::ENGLISH2CHINESE,
         vocab_resource: MarianVocabResources::ENGLISH2CHINESE,
         merges_resource: MarianSpmResources::ENGLISH2CHINESE,
-        prefix: MarianPrefix::ENGLISH2CANTONESE,
+        prefix: MarianPrefix::ENGLISH2CHINESE_TRADITIONAL,
         model_type: ModelType::Marian,
     };
     pub const ENGLISH2SWEDISH: RemoteTranslationResources = Self {
@@ -458,8 +458,12 @@ impl TranslationConfig {
             Language::EnglishToGerman => RemoteTranslationResources::ENGLISH2GERMAN,
             Language::EnglishToRussian => RemoteTranslationResources::ENGLISH2RUSSIAN,
             Language::EnglishToDutch => RemoteTranslationResources::ENGLISH2DUTCH,
-            Language::EnglishToMandarin => RemoteTranslationResources::ENGLISH2MANDARIN,
-            Language::EnglishToCantonese => RemoteTranslationResources::ENGLISH2CANTONESE,
+            Language::EnglishToChineseSimplified => {
+                RemoteTranslationResources::ENGLISH2CHINESE_SIMPLIFIED
+            }
+            Language::EnglishToChineseTraditional => {
+                RemoteTranslationResources::ENGLISH2CHINESE_TRADITIONAL
+            }
             Language::EnglishToSwedish => RemoteTranslationResources::ENGLISH2SWEDISH,
             Language::EnglishToArabic => RemoteTranslationResources::ENGLISH2ARABIC,
             Language::EnglishToHindi => RemoteTranslationResources::ENGLISH2HINDI,
@@ -761,6 +765,7 @@ impl TranslationModel {
         }
     }
 }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -77,6 +77,7 @@ pub enum Language {
     GermanToEnglish,
     RussianToEnglish,
     DutchToEnglish,
+    ChineseToEnglish,
     EnglishToFrench,
     EnglishToCatalan,
     EnglishToSpanish,
@@ -86,6 +87,8 @@ pub enum Language {
     EnglishToGerman,
     EnglishToRussian,
     EnglishToDutch,
+    EnglishToMandarin,
+    EnglishToCantonese,
     EnglishToFrenchV2,
     EnglishToGermanV2,
     FrenchToGerman,
@@ -278,6 +281,30 @@ impl RemoteTranslationResources {
         prefix: MarianPrefix::DUTCH2ENGLISH,
         model_type: ModelType::Marian,
     };
+    pub const CHINESE2ENGLISH: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::CHINESE2ENGLISH,
+        config_resource: MarianConfigResources::CHINESE2ENGLISH,
+        vocab_resource: MarianVocabResources::CHINESE2ENGLISH,
+        merges_resource: MarianSpmResources::CHINESE2ENGLISH,
+        prefix: MarianPrefix::CHINESE2ENGLISH,
+        model_type: ModelType::Marian,
+    };
+    pub const ENGLISH2MANDARIN: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2CHINESE,
+        config_resource: MarianConfigResources::ENGLISH2CHINESE,
+        vocab_resource: MarianVocabResources::ENGLISH2CHINESE,
+        merges_resource: MarianSpmResources::ENGLISH2CHINESE,
+        prefix: MarianPrefix::ENGLISH2MANDARIN,
+        model_type: ModelType::Marian,
+    };
+    pub const ENGLISH2CANTONESE: RemoteTranslationResources = Self {
+        model_resource: MarianModelResources::ENGLISH2CHINESE,
+        config_resource: MarianConfigResources::ENGLISH2CHINESE,
+        vocab_resource: MarianVocabResources::ENGLISH2CHINESE,
+        merges_resource: MarianSpmResources::ENGLISH2CHINESE,
+        prefix: MarianPrefix::ENGLISH2CANTONESE,
+        model_type: ModelType::Marian,
+    };
 }
 
 /// # Configuration for text translation
@@ -359,6 +386,8 @@ impl TranslationConfig {
             Language::EnglishToGerman => RemoteTranslationResources::ENGLISH2GERMAN,
             Language::EnglishToRussian => RemoteTranslationResources::ENGLISH2RUSSIAN,
             Language::EnglishToDutch => RemoteTranslationResources::ENGLISH2DUTCH,
+            Language::EnglishToMandarin => RemoteTranslationResources::ENGLISH2MANDARIN,
+            Language::EnglishToCantonese => RemoteTranslationResources::ENGLISH2CANTONESE,
 
             Language::FrenchToEnglish => RemoteTranslationResources::FRENCH2ENGLISH,
             Language::CatalanToEnglish => RemoteTranslationResources::CATALAN2ENGLISH,
@@ -369,6 +398,7 @@ impl TranslationConfig {
             Language::GermanToEnglish => RemoteTranslationResources::GERMAN2ENGLISH,
             Language::RussianToEnglish => RemoteTranslationResources::RUSSIAN2ENGLISH,
             Language::DutchToEnglish => RemoteTranslationResources::DUTCH2ENGLISH,
+            Language::ChineseToEnglish => RemoteTranslationResources::CHINESE2ENGLISH,
 
             Language::EnglishToFrenchV2 => RemoteTranslationResources::ENGLISH2FRENCH_V2,
             Language::EnglishToGermanV2 => RemoteTranslationResources::ENGLISH2GERMAN_V2,


### PR DESCRIPTION
Addition of multiple translation language pairs:
  - English <-> Mandarin
  - English <-> Cantonese
  - English <-> Dutch
  - English <-> Swedish
  - English <-> Arabic
  - English <-> Hebrew
  - English <-> Hindi