### PR TITLE
Prefix allowed tokens implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## Added
+- (BREAKING) Support for `prefix_allowed_tokens_fn` arguments for generation, allowing users to control the generation via custom functions
 
 ## [0.15.1] - 2021-06-01
 ### Fixed

--- a/examples/t5.rs
+++ b/examples/t5.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
     //    Define input
     let input = ["translate English to German: This sentence will get translated to German"];
 
-    let output = t5_model.generate(Some(input.to_vec()), None, None, None, None);
+    let output = t5_model.generate(Some(input.to_vec()), None, None, None, None, None);
     println!("{:?}", output);
 
     Ok(())

--- a/src/pipelines/conversation.rs
+++ b/src/pipelines/conversation.rs
@@ -717,7 +717,7 @@ impl ConversationOption {
     ) -> Vec<Vec<i64>> {
         match *self {
             Self::GPT2(ref model) => {
-                model.generate_from_ids_and_past(input_ids, attention_mask, None, None, None)
+                model.generate_from_ids_and_past(input_ids, attention_mask, None, None, None, None)
             }
         }
     }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1187,7 +1187,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// * `min_length` - `impl Into<Option<i64>>` Optional minimum output sequence length
     /// * `max_length` - `impl Into<Option<i64>>` Optional maximum output sequence length
     /// * `decoder_start_token_id` - `impl Into<Option<i64>>` Optional decoder start token id
-    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor)` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
+    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
     ///
     /// # Returns
     /// * `Vec<String>` Vector of generated strings based on the prompts of length *number_of_prompts* x *num_return_sequences*.
@@ -1303,7 +1303,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// * `min_length` - `impl Into<Option<i64>>` Optional minimum output sequence length
     /// * `max_length` - `impl Into<Option<i64>>` Optional maximum output sequence length
     /// * `decoder_start_token_id` - `impl Into<Option<i64>>` Optional decoder start token id
-    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor)` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
+    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
     ///
     /// # Returns
     /// * `Vec<Vec<i64>>` Vector of Vector of generated token indices based on the prompts of length *number_of_prompts* x *num_return_sequences*.
@@ -1426,7 +1426,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// * `min_length` - `impl Into<Option<i64>>` Optional minimum output sequence length
     /// * `max_length` - `impl Into<Option<i64>>` Optional maximum output sequence length
     /// * `decoder_start_token_id` - `impl Into<Option<i64>>` Optional decoder start token id
-    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor)` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
+    /// * `prefix_allowed_tokens_fn` - `Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>` Optional function to control the generation process. The function should take a `batch_id` (i64) and a tensor of token_ids already generated and returns a `Vec<i64>` of allowed tokens.
     ///
     /// # Returns
     /// * `Vec<Vec<i64>>` Vector of Vector of generated token indices based on the prompts of length *number_of_prompts* x *num_return_sequences*.

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1202,6 +1202,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         min_length: impl Into<Option<i64>>,
         max_length: impl Into<Option<i64>>,
         decoder_start_token_id: impl Into<Option<i64>>,
+        prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
     ) -> Vec<String>
     where
         S: AsRef<[&'a str]>,
@@ -1212,6 +1213,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             min_length,
             max_length,
             decoder_start_token_id,
+            prefix_allowed_tokens_fn,
         );
         let mut output = Vec::with_capacity(generated.len());
         for generated_sequence in generated {
@@ -1279,6 +1281,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         min_length: impl Into<Option<i64>>,
         max_length: impl Into<Option<i64>>,
         decoder_start_token_id: impl Into<Option<i64>>,
+        prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
     ) -> Vec<Vec<i64>>
     where
         S: AsRef<[&'a str]>,
@@ -1314,6 +1317,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             min_length,
             max_length,
             decoder_start_token_id,
+            prefix_allowed_tokens_fn,
         )
     }
 
@@ -1324,6 +1328,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         min_length: impl Into<Option<i64>>,
         max_length: impl Into<Option<i64>>,
         decoder_start_token_id: impl Into<Option<i64>>,
+        prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
     ) -> Vec<Vec<i64>> {
         let eos_token_ids = PrivateLanguageGenerator::get_eos_ids(self).clone();
 

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -263,13 +263,17 @@ impl SummarizationOption {
         S: AsRef<[&'a str]>,
     {
         match *self {
-            Self::Bart(ref model) => model.generate(prompt_texts, attention_mask, None, None, None),
-            Self::T5(ref model) => model.generate(prompt_texts, attention_mask, None, None, None),
+            Self::Bart(ref model) => {
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
+            }
+            Self::T5(ref model) => {
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
+            }
             Self::ProphetNet(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None)
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
             }
             Self::Pegasus(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None)
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
             }
         }
     }

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -249,21 +249,46 @@ impl TextGenerationOption {
         S: AsRef<[&'a str]>,
     {
         match *self {
-            Self::GPT(ref model) => {
-                model.generate_indices(prompt_texts, attention_mask, min_length, max_length, None)
-            }
-            Self::GPT2(ref model) => {
-                model.generate_indices(prompt_texts, attention_mask, min_length, max_length, None)
-            }
-            Self::GPTNeo(ref model) => {
-                model.generate_indices(prompt_texts, attention_mask, min_length, max_length, None)
-            }
-            Self::XLNet(ref model) => {
-                model.generate_indices(prompt_texts, attention_mask, min_length, max_length, None)
-            }
-            Self::Reformer(ref model) => {
-                model.generate_indices(prompt_texts, attention_mask, min_length, max_length, None)
-            }
+            Self::GPT(ref model) => model.generate_indices(
+                prompt_texts,
+                attention_mask,
+                min_length,
+                max_length,
+                None,
+                None,
+            ),
+            Self::GPT2(ref model) => model.generate_indices(
+                prompt_texts,
+                attention_mask,
+                min_length,
+                max_length,
+                None,
+                None,
+            ),
+            Self::GPTNeo(ref model) => model.generate_indices(
+                prompt_texts,
+                attention_mask,
+                min_length,
+                max_length,
+                None,
+                None,
+            ),
+            Self::XLNet(ref model) => model.generate_indices(
+                prompt_texts,
+                attention_mask,
+                min_length,
+                max_length,
+                None,
+                None,
+            ),
+            Self::Reformer(ref model) => model.generate_indices(
+                prompt_texts,
+                attention_mask,
+                min_length,
+                max_length,
+                None,
+                None,
+            ),
         }
     }
 }

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -675,9 +675,11 @@ impl TranslationOption {
     {
         match *self {
             Self::Marian(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None)
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
             }
-            Self::T5(ref model) => model.generate(prompt_texts, attention_mask, None, None, None),
+            Self::T5(ref model) => {
+                model.generate(prompt_texts, attention_mask, None, None, None, None)
+            }
         }
     }
 }

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -1,12 +1,14 @@
 use rust_bert::gpt2::{
-    GPT2LMHeadModel, Gpt2Config, Gpt2ConfigResources, Gpt2MergesResources, Gpt2ModelResources,
-    Gpt2VocabResources,
+    GPT2Generator, GPT2LMHeadModel, Gpt2Config, Gpt2ConfigResources, Gpt2MergesResources,
+    Gpt2ModelResources, Gpt2VocabResources,
 };
 use rust_bert::pipelines::common::ModelType;
 use rust_bert::pipelines::conversation::{
     ConversationConfig, ConversationManager, ConversationModel,
 };
-use rust_bert::pipelines::generation_utils::{Cache, LMHeadModel};
+use rust_bert::pipelines::generation_utils::{
+    Cache, GenerateConfig, LMHeadModel, LanguageGenerator,
+};
 use rust_bert::pipelines::text_generation::{TextGenerationConfig, TextGenerationModel};
 use rust_bert::resources::{RemoteResource, Resource};
 use rust_bert::Config;
@@ -29,7 +31,6 @@ fn gpt2_lm_model() -> anyhow::Result<()> {
     let merges_path = merges_resource.get_local_path()?;
     let weights_path = weights_resource.get_local_path()?;
 
-    //    Set-up masked LM model
     let device = Device::Cpu;
     let mut vs = nn::VarStore::new(device);
     let tokenizer: Gpt2Tokenizer = Gpt2Tokenizer::from_file(
@@ -122,7 +123,6 @@ fn gpt2_generation_greedy() -> anyhow::Result<()> {
     let model_resource =
         Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
 
-    //    Set-up masked LM model
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         model_resource,
@@ -159,7 +159,6 @@ fn gpt2_generation_beam_search() -> anyhow::Result<()> {
     let model_resource =
         Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
 
-    //    Set-up masked LM model
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         model_resource,
@@ -208,7 +207,6 @@ fn gpt2_generation_beam_search_multiple_prompts_without_padding() -> anyhow::Res
     let model_resource =
         Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
 
-    //    Set-up masked LM model
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         model_resource,
@@ -270,7 +268,6 @@ fn gpt2_generation_beam_search_multiple_prompts_with_padding() -> anyhow::Result
     let model_resource =
         Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
 
-    //    Set-up masked LM model
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         model_resource,
@@ -331,7 +328,6 @@ fn gpt2_diverse_beam_search_multiple_prompts_with_padding() -> anyhow::Result<()
     let model_resource =
         Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
 
-    //    Set-up masked LM model
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         model_resource,
@@ -377,6 +373,134 @@ fn gpt2_diverse_beam_search_multiple_prompts_with_padding() -> anyhow::Result<()
     assert_eq!(
         output[5],
         "Language models can generate a lot of data, but they're not the only way to do it"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
+    //    Resources definition
+    let config_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2ConfigResources::GPT2));
+    let vocab_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2VocabResources::GPT2));
+    let merges_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2MergesResources::GPT2));
+    let model_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
+
+    fn force_one_paragraph(_batch_id: i64, previous_token_ids: &Tensor) -> Vec<i64> {
+        let paragraph_tokens = [198, 628];
+
+        for paragraph_token in paragraph_tokens.iter() {
+            if previous_token_ids
+                .iter::<i64>()
+                .unwrap()
+                .collect::<Vec<i64>>()
+                .contains(paragraph_token)
+            {
+                return vec![50256];
+            }
+        }
+        (0..50255).collect()
+    }
+
+    let generate_config = GenerateConfig {
+        max_length: 56,
+        model_resource,
+        config_resource,
+        vocab_resource,
+        merges_resource,
+        do_sample: false,
+        num_beams: 1,
+        ..Default::default()
+    };
+    let model = GPT2Generator::new(generate_config)?;
+
+    let input_context_1 = "Rust is a";
+    let input_context_2 = "There was a ";
+    let output = model.generate(
+        Some(&[input_context_1, input_context_2]),
+        None,
+        None,
+        None,
+        None,
+        Some(&force_one_paragraph),
+    );
+
+    assert_eq!(output.len(), 2);
+    assert_eq!(
+        output[0],
+        "Rust is a very simple and powerful library for building and running web applications. It is a simple, fast, and lightweight library that can be used to build web applications in a number of different ways.\n"
+    );
+    assert_eq!(
+        output[1],
+        "There was a urn in the room, and I was sitting on it. I was like, \'What the hell is going on?\' And he said, \'Well, I\'m not sure. I\'m just going to go back to my room and get some coffee.\' And"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
+    //    Resources definition
+    let config_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2ConfigResources::GPT2));
+    let vocab_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2VocabResources::GPT2));
+    let merges_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2MergesResources::GPT2));
+    let model_resource =
+        Resource::Remote(RemoteResource::from_pretrained(Gpt2ModelResources::GPT2));
+
+    fn force_one_paragraph(_batch_id: i64, previous_token_ids: &Tensor) -> Vec<i64> {
+        let paragraph_tokens = [198, 628];
+
+        for paragraph_token in paragraph_tokens.iter() {
+            if previous_token_ids
+                .iter::<i64>()
+                .unwrap()
+                .collect::<Vec<i64>>()
+                .contains(paragraph_token)
+            {
+                return vec![50256];
+            }
+        }
+        (0..50255).collect()
+    }
+
+    let generate_config = GenerateConfig {
+        max_length: 32,
+        model_resource,
+        config_resource,
+        vocab_resource,
+        merges_resource,
+        do_sample: false,
+        num_beams: 3,
+        ..Default::default()
+    };
+    let model = GPT2Generator::new(generate_config)?;
+
+    let input_context_1 = "Rust is a";
+    let input_context_2 = "There was a ";
+    let output = model.generate(
+        Some(&[input_context_1, input_context_2]),
+        None,
+        None,
+        None,
+        None,
+        Some(&force_one_paragraph),
+    );
+
+    assert_eq!(output.len(), 2);
+    assert_eq!(
+        output[0],
+        "Rust is a simple, fast, and easy-to-use framework for building web applications. It is designed to be easy to use and maintain, and"
+    );
+    assert_eq!(
+        output[1],
+        "There was a urn in the back of the room, and I was sitting on it, and it looked like it was going to explode. And then I"
     );
 
     Ok(())

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -397,8 +397,7 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
             if previous_token_ids
                 .iter::<i64>()
                 .unwrap()
-                .collect::<Vec<i64>>()
-                .contains(paragraph_token)
+                .any(|x| x == *paragraph_token)
             {
                 return vec![50256];
             }
@@ -462,8 +461,7 @@ fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
             if previous_token_ids
                 .iter::<i64>()
                 .unwrap()
-                .collect::<Vec<i64>>()
-                .contains(paragraph_token)
+                .any(|x| x == *paragraph_token)
             {
                 return vec![50256];
             }

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -414,6 +414,7 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
         merges_resource,
         do_sample: false,
         num_beams: 1,
+        device: Device::Cpu,
         ..Default::default()
     };
     let model = GPT2Generator::new(generate_config)?;
@@ -478,6 +479,7 @@ fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
         merges_resource,
         do_sample: false,
         num_beams: 3,
+        device: Device::Cpu,
         ..Default::default()
     };
     let model = GPT2Generator::new(generate_config)?;


### PR DESCRIPTION
- Support for `prefix_allowed_tokens_function` argument (based on the [python implementation](https://github.com/huggingface/transformers/blob/61c506349134db0a0a2fd6fb2eff8e29a2f84e79/src/transformers/generation_utils.py#L670)) allowing to pass a user-defined function for fine-grained generation control, for example as in this [colab notebook contributed by @paulbricman ](https://colab.research.google.com/drive/1yD8AIfv4V-UXCV9p5PlFDRBas_KiP2rZ?usp=sharing))

Fixes https://github.com/guillaume-be/rust-bert/issues/152