### PR TITLE
Calculation and output of generation scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 ## Added
-- (BREAKING) Support for `prefix_allowed_tokens_fn` argument  for generation, allowing users to control the generation via custom functions
+- (BREAKING) Support for `prefix_allowed_tokens_fn` argument for generation, allowing users to control the generation via custom functions
 - (BREAKING) Support for `forced_bos_token_id` argument for generation, allowing users to force a given BOS token for generation (useful for MBart/M2M-class models)
+- (BREAKING) Support for `output_scores` boolean argument for generation, allowing users to output the log-probability scores of generated sequences. Updated the return type of low-level generate API to `GeneratedTextOutput` and `GeneratedIndicesOutput` containing optional scores along with the generated output.
 - Addition of the MBart Language model and support for text generation / direct translation between 50 language
 
 ## Changed

--- a/examples/generation_gpt2.rs
+++ b/examples/generation_gpt2.rs
@@ -20,17 +20,17 @@ fn main() -> anyhow::Result<()> {
     let generate_config = TextGenerationConfig {
         model_type: ModelType::GPT2,
         max_length: 30,
-        do_sample: true,
-        num_beams: 5,
-        temperature: 1.1,
-        num_return_sequences: 3,
+        do_sample: false,
+        num_beams: 1,
+        temperature: 1.0,
+        num_return_sequences: 1,
         ..Default::default()
     };
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "The dog";
-    let second_input_context = "The cat was";
-    let output = model.generate(&[input_context, second_input_context], None);
+    // let second_input_context = "The cat was";
+    let output = model.generate(&[input_context], None);
 
     for sentence in output {
         println!("{:?}", sentence);

--- a/examples/translation_mbart.rs
+++ b/examples/translation_mbart.rs
@@ -50,10 +50,11 @@ fn main() -> anyhow::Result<()> {
         None,
         target_language,
         None,
+        false,
     );
 
     for sentence in output {
-        println!("{:?}", sentence);
+        println!("{:?}", sentence.text);
     }
     Ok(())
 }

--- a/examples/translation_t5.rs
+++ b/examples/translation_t5.rs
@@ -41,7 +41,16 @@ fn main() -> anyhow::Result<()> {
     //    Define input
     let input = ["translate English to German: This sentence will get translated to German"];
 
-    let output = t5_model.generate(Some(input.to_vec()), None, None, None, None, None, None);
+    let output = t5_model.generate(
+        Some(input.to_vec()),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
     println!("{:?}", output);
 
     Ok(())

--- a/src/bert/encoder.rs
+++ b/src/bert/encoder.rs
@@ -131,11 +131,12 @@ impl BertLayer {
         encoder_mask: &Option<Tensor>,
         train: bool,
     ) -> BertLayerOutput {
+        let (attention_output, attention_weights) =
+            self.attention
+                .forward_t(hidden_states, mask, &None, &None, train);
+
         let (attention_output, attention_scores, cross_attention_scores) =
             if self.is_decoder & encoder_hidden_states.is_some() {
-                let (attention_output, attention_weights) =
-                    self.attention
-                        .forward_t(hidden_states, mask, &None, &None, train);
                 let (attention_output, cross_attention_weights) =
                     self.cross_attention.as_ref().unwrap().forward_t(
                         &attention_output,
@@ -146,9 +147,6 @@ impl BertLayer {
                     );
                 (attention_output, attention_weights, cross_attention_weights)
             } else {
-                let (attention_output, attention_weights) =
-                    self.attention
-                        .forward_t(hidden_states, mask, &None, &None, train);
                 (attention_output, attention_weights, None)
             };
 

--- a/src/common/summary.rs
+++ b/src/common/summary.rs
@@ -78,7 +78,7 @@ impl SequenceSummary {
     {
         let p = p.borrow();
 
-        let summary_type = config.summary_type.clone().unwrap_or(SummaryType::last);
+        let summary_type = config.summary_type.unwrap_or(SummaryType::last);
         let summary = if let Some(summary_use_proj) = config.summary_use_proj {
             let num_classes = match (config.summary_proj_to_labels, config.num_labels) {
                 (Some(summary_proj_to_labels), Some(num_labels))

--- a/src/pipelines/conversation.rs
+++ b/src/pipelines/conversation.rs
@@ -716,16 +716,20 @@ impl ConversationOption {
         attention_mask: Option<Tensor>,
     ) -> Vec<Vec<i64>> {
         match *self {
-            Self::GPT2(ref model) => model.generate_from_ids_and_past(
-                input_ids,
-                attention_mask,
-                None,
-                None,
-                None,
-                None,
-                None,
-                false,
-            ),
+            Self::GPT2(ref model) => model
+                .generate_from_ids_and_past(
+                    input_ids,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
         }
     }
 }

--- a/src/pipelines/conversation.rs
+++ b/src/pipelines/conversation.rs
@@ -724,6 +724,7 @@ impl ConversationOption {
                 None,
                 None,
                 None,
+                false,
             ),
         }
     }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1218,7 +1218,7 @@ pub(crate) mod private_generation_utils {
 #[derive(Debug, Clone)]
 /// # Generated text output
 /// Contains generated text and an optional log-likelihood score for the generated sequence
-pub struct TextOutput {
+pub struct GeneratedTextOutput {
     pub text: String,
     pub score: Option<f64>,
 }
@@ -1226,7 +1226,7 @@ pub struct TextOutput {
 #[derive(Debug, Clone)]
 /// # Generated indices output
 /// Contains generated indices and an optional log-likelihood score for the generated sequence
-pub struct IndicesOutput {
+pub struct GeneratedIndicesOutput {
     pub indices: Vec<i64>,
     pub score: Option<f64>,
 }
@@ -1339,7 +1339,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         forced_bos_token_id: impl Into<Option<i64>>,
         prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
         output_scores: bool,
-    ) -> Vec<TextOutput>
+    ) -> Vec<GeneratedTextOutput>
     where
         S: AsRef<[&'a str]>,
     {
@@ -1355,7 +1355,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         );
         let mut output = Vec::with_capacity(indices_outputs.len());
         for generated_sequence in indices_outputs {
-            output.push(TextOutput {
+            output.push(GeneratedTextOutput {
                 text: self
                     ._get_tokenizer()
                     .decode(generated_sequence.indices, true, true),
@@ -1454,7 +1454,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         forced_bos_token_id: impl Into<Option<i64>>,
         prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
         output_scores: bool,
-    ) -> Vec<IndicesOutput>
+    ) -> Vec<GeneratedIndicesOutput>
     where
         S: AsRef<[&'a str]>,
     {
@@ -1585,7 +1585,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         forced_bos_token_id: impl Into<Option<i64>>,
         prefix_allowed_tokens_fn: Option<&dyn Fn(i64, &Tensor) -> Vec<i64>>,
         output_scores: bool,
-    ) -> Vec<IndicesOutput> {
+    ) -> Vec<GeneratedIndicesOutput> {
         let eos_token_ids = PrivateLanguageGenerator::get_eos_ids(self).clone();
 
         let config = PrivateLanguageGenerator::get_config(self);
@@ -1753,7 +1753,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             let score = scores
                 .as_ref()
                 .map(|scores_value| scores_value[sequence_index as usize]);
-            output.push(IndicesOutput { indices, score });
+            output.push(GeneratedIndicesOutput { indices, score });
         }
         output
     }

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -263,18 +263,62 @@ impl SummarizationOption {
         S: AsRef<[&'a str]>,
     {
         match *self {
-            Self::Bart(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
-            Self::T5(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
-            Self::ProphetNet(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
-            Self::Pegasus(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
+            Self::Bart(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
+            Self::T5(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
+            Self::ProphetNet(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
+            Self::Pegasus(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
         }
     }
 }

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -249,56 +249,76 @@ impl TextGenerationOption {
         S: AsRef<[&'a str]>,
     {
         match *self {
-            Self::GPT(ref model) => model.generate_indices(
-                prompt_texts,
-                attention_mask,
-                min_length,
-                max_length,
-                None,
-                None,
-                None,
-                false,
-            ),
-            Self::GPT2(ref model) => model.generate_indices(
-                prompt_texts,
-                attention_mask,
-                min_length,
-                max_length,
-                None,
-                None,
-                None,
-                false,
-            ),
-            Self::GPTNeo(ref model) => model.generate_indices(
-                prompt_texts,
-                attention_mask,
-                min_length,
-                max_length,
-                None,
-                None,
-                None,
-                false,
-            ),
-            Self::XLNet(ref model) => model.generate_indices(
-                prompt_texts,
-                attention_mask,
-                min_length,
-                max_length,
-                None,
-                None,
-                None,
-                false,
-            ),
-            Self::Reformer(ref model) => model.generate_indices(
-                prompt_texts,
-                attention_mask,
-                min_length,
-                max_length,
-                None,
-                None,
-                None,
-                false,
-            ),
+            Self::GPT(ref model) => model
+                .generate_indices(
+                    prompt_texts,
+                    attention_mask,
+                    min_length,
+                    max_length,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
+            Self::GPT2(ref model) => model
+                .generate_indices(
+                    prompt_texts,
+                    attention_mask,
+                    min_length,
+                    max_length,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
+            Self::GPTNeo(ref model) => model
+                .generate_indices(
+                    prompt_texts,
+                    attention_mask,
+                    min_length,
+                    max_length,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
+            Self::XLNet(ref model) => model
+                .generate_indices(
+                    prompt_texts,
+                    attention_mask,
+                    min_length,
+                    max_length,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
+            Self::Reformer(ref model) => model
+                .generate_indices(
+                    prompt_texts,
+                    attention_mask,
+                    min_length,
+                    max_length,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.indices)
+                .collect(),
         }
     }
 }

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -257,6 +257,7 @@ impl TextGenerationOption {
                 None,
                 None,
                 None,
+                false,
             ),
             Self::GPT2(ref model) => model.generate_indices(
                 prompt_texts,
@@ -266,6 +267,7 @@ impl TextGenerationOption {
                 None,
                 None,
                 None,
+                false,
             ),
             Self::GPTNeo(ref model) => model.generate_indices(
                 prompt_texts,
@@ -275,6 +277,7 @@ impl TextGenerationOption {
                 None,
                 None,
                 None,
+                false,
             ),
             Self::XLNet(ref model) => model.generate_indices(
                 prompt_texts,
@@ -284,6 +287,7 @@ impl TextGenerationOption {
                 None,
                 None,
                 None,
+                false,
             ),
             Self::Reformer(ref model) => model.generate_indices(
                 prompt_texts,
@@ -293,6 +297,7 @@ impl TextGenerationOption {
                 None,
                 None,
                 None,
+                false,
             ),
         }
     }

--- a/src/pipelines/translation.rs
+++ b/src/pipelines/translation.rs
@@ -674,12 +674,34 @@ impl TranslationOption {
         S: AsRef<[&'a str]>,
     {
         match *self {
-            Self::Marian(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
-            Self::T5(ref model) => {
-                model.generate(prompt_texts, attention_mask, None, None, None, None, None)
-            }
+            Self::Marian(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
+            Self::T5(ref model) => model
+                .generate(
+                    prompt_texts,
+                    attention_mask,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .into_iter()
+                .map(|output| output.text)
+                .collect(),
         }
     }
 }

--- a/src/prophetnet/decoder.rs
+++ b/src/prophetnet/decoder.rs
@@ -308,9 +308,9 @@ impl ProphetNetDecoder {
 
         let hidden_states = (input_embeds + main_stream_pos_embed).transpose(0, 1);
 
-        let (mut ngram_hidden_states, extended_attention_mask, extended_predict_attention_mask) =
+        let (mut ngram_hidden_states, extended_attention_mask, extended_predict_attention_mask) = {
+            let mut ngram_hidden_states = Vec::with_capacity(self.ngram as usize);
             if old_layer_states.is_some() {
-                let mut ngram_hidden_states = Vec::with_capacity(self.ngram as usize);
                 for ngram in 0..self.ngram {
                     ngram_hidden_states.push(
                         (&self.ngram_embeddings.get(ngram - 1) + &predicting_stream_pos_embed)
@@ -320,7 +320,6 @@ impl ProphetNetDecoder {
                 }
                 (ngram_hidden_states, None, None)
             } else {
-                let mut ngram_hidden_states = Vec::with_capacity(self.ngram as usize);
                 for ngram in 0..self.ngram {
                     ngram_hidden_states.push(
                         (&self.ngram_embeddings.get(ngram - 1) + &predicting_stream_pos_embed)
@@ -336,7 +335,8 @@ impl ProphetNetDecoder {
                     Some(extended_attention_mask),
                     Some(extended_predict_attention_mask),
                 )
-            };
+            }
+        };
 
         let extended_encoder_attention_mask =
             encoder_attention_mask.map(|encoder_attention_mask_value| {

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -428,17 +428,20 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
         None,
         None,
         Some(&force_one_paragraph),
+        true,
     );
 
     assert_eq!(output.len(), 2);
     assert_eq!(
-        output[0],
+        output[0].text,
         "Rust is a very simple and powerful library for building and running web applications. It is a simple, fast, and lightweight library that can be used to build web applications in a number of different ways.\n"
     );
+    assert!(output[0].score.unwrap().is_nan());
     assert_eq!(
-        output[1],
+        output[1].text,
         "There was a urn in the room, and I was sitting on it. I was like, \'What the hell is going on?\' And he said, \'Well, I\'m not sure. I\'m just going to go back to my room and get some coffee.\' And"
     );
+    assert!(output[1].score.unwrap().is_nan());
 
     Ok(())
 }
@@ -493,17 +496,20 @@ fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
         None,
         None,
         Some(&force_one_paragraph),
+        true,
     );
 
     assert_eq!(output.len(), 2);
     assert_eq!(
-        output[0],
+        output[0].text,
         "Rust is a simple, fast, and easy-to-use framework for building web applications. It is designed to be easy to use and maintain, and"
     );
+    assert!((output[0].score.unwrap() - (-1.2750)).abs() < 1e-4);
     assert_eq!(
-        output[1],
+        output[1].text,
         "There was a urn in the back of the room, and I was sitting on it, and it looked like it was going to explode. And then I"
     );
+    assert!((output[1].score.unwrap() - (-1.3326)).abs() < 1e-4);
 
     Ok(())
 }

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -436,12 +436,12 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
         output[0].text,
         "Rust is a very simple and powerful library for building and running web applications. It is a simple, fast, and lightweight library that can be used to build web applications in a number of different ways.\n"
     );
-    assert!(output[0].score.unwrap().is_nan());
+    assert!((output[0].score.unwrap() - (-1.4666)).abs() < 1e-4);
     assert_eq!(
         output[1].text,
         "There was a urn in the room, and I was sitting on it. I was like, \'What the hell is going on?\' And he said, \'Well, I\'m not sure. I\'m just going to go back to my room and get some coffee.\' And"
     );
-    assert!(output[1].score.unwrap().is_nan());
+    assert!((output[1].score.unwrap() - (-1.3545)).abs() < 1e-4);
 
     Ok(())
 }

--- a/tests/mbart.rs
+++ b/tests/mbart.rs
@@ -97,11 +97,12 @@ fn mbart_translation() -> anyhow::Result<()> {
         None,
         target_language,
         None,
+        false,
     );
 
     assert_eq!(output.len(), 1);
     assert_eq!(
-        output[0],
+        output[0].text,
         "de_DE Der schnelle braune Fuchs springt über den faulen Hund."
     );
 


### PR DESCRIPTION
- Compute the log-probability of generated sequences for greedy and beam search generation
-  Allow users to return these log-probabilities by turning a new `output_scores` flag on in the low-level generation API
- Updated the return type of low-level generation API to `GeneratedTextOutput` and `GeneratedIndicesOutput` structs containing the output and an optional score field (`Option<f64>`)
- Enables use-cases such as https://github.com/guillaume-be/rust-bert/issues/161