### PR TITLE
Floor divide deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Changed
 - Updated GPT2 architecture to re-use embeddings for the output projection layer (resulting in smaller model weights files and memory footprint)
+- Upgraded `tch` version to 0.5.0 (using `libtorch` 1.9.0)
 
 ## [0.15.1] - 2021-06-01
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ This cache location defaults to `~/.cache/.rustbert`, but can be changed by sett
 
 ### Manual installation (recommended)
 
-1. Download `libtorch` from https://pytorch.org/get-started/locally/. This package requires `v1.8.1`: if this version is no longer available on the "get started" page,
-the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.8.1%2Bcu111.zip` for a Linux version with CUDA11.
+1. Download `libtorch` from https://pytorch.org/get-started/locally/. This package requires `v1.9.0`: if this version is no longer available on the "get started" page,
+the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.9.0%2Bcu111.zip` for a Linux version with CUDA11.
 2. Extract the library to a location of your choice
 3. Set the following environment variables
 ##### Linux:

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -989,7 +989,7 @@ pub(crate) mod private_generation_utils {
                     };
 
                     let eos_token_ids = gen_opt.eos_token_ids.as_ref();
-                    let beam_ids_tensor = &next_tokens.floor_divide_scalar(vocab_size);
+                    let beam_ids_tensor = &next_tokens.divide_scalar_mode(vocab_size, "floor");
                     let effective_beam_ids_tensor = (&next_tokens.ones_like().cumsum(0, Int64) - 1)
                         * group_size
                         + beam_ids_tensor;
@@ -1063,7 +1063,7 @@ pub(crate) mod private_generation_utils {
                             &group_beam_tokens,
                         );
                         let new_indices = gen_opt.num_beams
-                            * group_beam_indices.floor_divide_scalar(group_size)
+                            * group_beam_indices.divide_scalar_mode(group_size, "floor")
                             + group_start_index
                             + group_beam_indices.remainder(group_size);
                         let _ = beam_indices.index_copy_(

--- a/src/reformer/attention.rs
+++ b/src/reformer/attention.rs
@@ -537,7 +537,10 @@ impl LSHSelfAttention {
                     *relevant_bucket_indices_chunk.size().last().unwrap(),
                     (Kind::Int64, hidden_states.device()),
                 )
-                .floor_divide_scalar(*relevant_bucket_indices_chunk.size().last().unwrap()));
+                .divide_scalar_mode(
+                    *relevant_bucket_indices_chunk.size().last().unwrap(),
+                    "floor",
+                ));
 
         let relevant_bucket_indices_chunk_all_batch =
             &relevant_bucket_indices_chunk + bucket_indices_batch_offset;
@@ -569,7 +572,9 @@ impl LSHSelfAttention {
         indices: &Tensor,
         sequence_length: i64,
     ) -> Tensor {
-        let start_indices_chunk = (indices.select(1, -1).floor_divide_scalar(self.chunk_length)
+        let start_indices_chunk = (indices
+            .select(1, -1)
+            .divide_scalar_mode(self.chunk_length, "floor")
             - self.num_chunks_before)
             * self.chunk_length;
         let total_chunk_size =

--- a/src/reformer/embeddings.rs
+++ b/src/reformer/embeddings.rs
@@ -263,10 +263,9 @@ impl ReformerEmbeddings {
 
         let calc_position_ids = if position_ids.is_none() {
             Some(
-                Tensor::arange_start_step(
+                Tensor::arange_start(
                     start_ids_pos_encoding,
                     start_ids_pos_encoding + input_shape[1],
-                    1,
                     (Kind::Int64, device),
                 )
                 .unsqueeze(0)

--- a/src/reformer/reformer_model.rs
+++ b/src/reformer/reformer_model.rs
@@ -418,10 +418,9 @@ impl ReformerModel {
             let input_ids = Tensor::cat(&[input_ids, &input_ids_padding], -1);
             new_input_shape = input_ids.size();
             let position_ids = if let Some(position_ids) = position_ids {
-                let position_ids_padding = Tensor::arange_start_step(
+                let position_ids_padding = Tensor::arange_start(
                     *input_shape.last().unwrap(),
                     self.least_common_mult_chunk_length,
-                    1,
                     (Kind::Int64, device),
                 )
                 .unsqueeze(0)

--- a/src/xlnet/xlnet_model.rs
+++ b/src/xlnet/xlnet_model.rs
@@ -305,7 +305,7 @@ impl XLNetModel {
         }
         if self.bi_data {
             let mut backward_positions_sequence =
-                Tensor::arange_start_step(-begin, -end, 1, (Kind::Float, device));
+                Tensor::arange_start(-begin, -end, (Kind::Float, device));
             match self.clamp_len {
                 Some(clamp_value) if clamp_value > 0 => {
                     let _ = backward_positions_sequence.clamp_(-clamp_value, clamp_value);


### PR DESCRIPTION
- Replace deprecated `floor_divide` by `divide_mode(..., "floor")`
- Replace unnecessary calls to `arange_start_step` when the step equals the default (1)