### PR TITLE
Additional runtime generation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 ## Added
 - (BREAKING) Support for `bad_word_ids` generation, allowing to ban a set of word ids for all model supporting text generation
+- (BREAKING) Extension of the generation options that can be provided at runtime (after a model has been instantiated with a `GenerateConfig`), allowing to update the generation options from one text generation to another with the same model. This feature is implemented at the `LanguageGenerator` trait level, the high-level `TextGeneration` pipeline API remains unchanged.
 
 ## [0.16.0] - 2021-08-24
 ## Added

--- a/README.md
+++ b/README.md
@@ -250,8 +250,12 @@ This may impact the results, it is recommended to submit prompts of similar leng
     let input_context_1 = "The dog";
     let input_context_2 = "The cat was";
 
-    let output = model.generate(Some(&[input_context_1, input_context_2]), 0, 30, true, false, 
-                                5, 1.2, 0, 0.9, 1.0, 1.0, 3, 3, None);
+    let generate_options = GenerateOptions {
+        max_length: 30,
+        ..Default::default()
+    };
+
+    let output = model.generate(Some(&[input_context_1, input_context_2]), generate_options);
 ```
 Example output:
 ```

--- a/src/pipelines/conversation.rs
+++ b/src/pipelines/conversation.rs
@@ -717,17 +717,7 @@ impl ConversationOption {
     ) -> Vec<Vec<i64>> {
         match *self {
             Self::GPT2(ref model) => model
-                .generate_from_ids_and_past(
-                    input_ids,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_from_ids_and_past(input_ids, attention_mask, None)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1936,7 +1936,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             length_penalty,
             num_beam_groups,
             diversity_penalty,
-            forced_bos_token_id: forced_bos_token_id.into(),
+            forced_bos_token_id,
             bad_word_ids,
         };
 

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -42,7 +42,6 @@
 //! let second_input_context = "The cat was";
 //! let output = gpt2_generator.generate(
 //!     Some(vec![input_context, second_input_context]),
-//!     None,
 //!     min_length,
 //!     max_length,
 //!     decoder_start_id,
@@ -1426,6 +1425,10 @@ pub struct GeneratedIndicesOutput {
     pub score: Option<f64>,
 }
 
+// pub struct GenerationOptions {
+//
+// }
+
 /// # Common trait for text generation models.
 /// Main API for text generation
 pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
@@ -1436,7 +1439,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// # Arguments
     ///
     /// * `prompt_texts` - `Option<Vec<&str>>` Optional vector of text prompts. An empty prompt to the model may be passed if the model implement a `bos_id`.
-    /// * `attention_mask` - `Option<Tensor>` Optional attention mask to hide portions of the prompt.
     /// * `min_length` - `impl Into<Option<i64>>` Optional minimum output sequence length
     /// * `max_length` - `impl Into<Option<i64>>` Optional maximum output sequence length
     /// * `decoder_start_token_id` - `impl Into<Option<i64>>` Optional decoder start token id
@@ -1474,7 +1476,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// let input_context = "The dog";
     /// let second_input_context = "The cat was";
     ///
-    /// let attention_mask = None;
     /// let min_length = 32;
     /// let max_length = 128;
     /// let decoder_start_token_id = None;
@@ -1501,7 +1502,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     ///
     /// let output = gpt2_generator.generate(
     ///     Some(vec![input_context, second_input_context]),
-    ///     attention_mask,
     ///     min_length,
     ///     max_length,
     ///     decoder_start_token_id,
@@ -1529,7 +1529,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     fn generate<'a, S>(
         &self,
         prompt_texts: Option<S>,
-        attention_mask: Option<Tensor>,
         min_length: impl Into<Option<i64>>,
         max_length: impl Into<Option<i64>>,
         decoder_start_token_id: impl Into<Option<i64>>,
@@ -1543,7 +1542,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     {
         let indices_outputs = self.generate_indices(
             prompt_texts,
-            attention_mask,
             min_length,
             max_length,
             decoder_start_token_id,
@@ -1569,7 +1567,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// # Arguments
     ///
     /// * `prompt_texts` - `Option<Vec<&str>>` Optional vector of text prompts. An empty prompt to the model may be passed if the model implement a `bos_id`.
-    /// * `attention_mask` - `Option<Tensor>` Optional attention mask to hide portions of the prompt.
     /// * `min_length` - `impl Into<Option<i64>>` Optional minimum output sequence length
     /// * `max_length` - `impl Into<Option<i64>>` Optional maximum output sequence length
     /// * `decoder_start_token_id` - `impl Into<Option<i64>>` Optional decoder start token id
@@ -1606,7 +1603,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// let gpt2_generator = GPT2Generator::new(generate_config)?;
     /// let input_context = "The dog";
     /// let second_input_context = "The cat was";
-    /// let attention_mask = None;
     /// let min_length = 32;
     /// let max_length = 128;
     /// let decoder_start_token_id = None;
@@ -1633,7 +1629,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     ///
     /// let output = gpt2_generator.generate_indices(
     ///     Some(vec![input_context, second_input_context]),
-    ///     attention_mask,
     ///     min_length,
     ///     max_length,
     ///     decoder_start_token_id,
@@ -1648,7 +1643,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     fn generate_indices<'a, S>(
         &self,
         prompt_texts: Option<S>,
-        attention_mask: Option<Tensor>,
         min_length: impl Into<Option<i64>>,
         max_length: impl Into<Option<i64>>,
         decoder_start_token_id: impl Into<Option<i64>>,
@@ -1687,7 +1681,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         };
         self.generate_from_ids_and_past(
             input_ids,
-            attention_mask,
+            None,
             min_length,
             max_length,
             decoder_start_token_id,
@@ -1741,7 +1735,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// let gpt2_generator = GPT2Generator::new(generate_config)?;
     /// let input_context = "The dog";
     /// let second_input_context = "The cat was";
-    /// let attention_mask = None;
     /// let min_length = 32;
     /// let max_length = 128;
     /// let decoder_start_token_id = None;
@@ -1768,7 +1761,6 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     ///
     /// let output = gpt2_generator.generate_indices(
     ///     Some(vec![input_context, second_input_context]),
-    ///     attention_mask,
     ///     min_length,
     ///     max_length,
     ///     decoder_start_token_id,

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -21,7 +21,9 @@
 //! ```no_run
 //! # fn main() -> anyhow::Result<()> {
 //! use rust_bert::gpt2::GPT2Generator;
-//! use rust_bert::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
+//! use rust_bert::pipelines::generation_utils::{
+//!     GenerateConfig, GenerateOptions, LanguageGenerator,
+//! };
 //!
 //! let generate_config = GenerateConfig {
 //!     do_sample: true,
@@ -31,7 +33,6 @@
 //!     ..Default::default()
 //! };
 //! let mut gpt2_generator = GPT2Generator::new(generate_config)?;
-//!
 //!
 //! let input_context = "The dog";
 //! let second_input_context = "The cat was";
@@ -1527,7 +1528,9 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// # use tch::Device;
     /// # fn main() -> anyhow::Result<()> {
     /// use rust_bert::gpt2::GPT2Generator;
-    /// use rust_bert::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
+    /// use rust_bert::pipelines::generation_utils::{
+    ///     GenerateConfig, GenerateOptions, LanguageGenerator,
+    /// };
     /// use tch::Tensor;
     /// # let mut home: PathBuf = dirs::home_dir().unwrap();
     /// # home.push("rustbert");
@@ -1576,7 +1579,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     ///
     /// let output = gpt2_generator.generate(
     ///     Some(vec![input_context, second_input_context]),
-    ///     Some(generate_options)
+    ///     Some(generate_options),
     /// );
     /// # Ok(())
     /// # }
@@ -1632,7 +1635,9 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// # use tch::Device;
     /// # fn main() -> anyhow::Result<()> {
     /// use rust_bert::gpt2::GPT2Generator;
-    /// use rust_bert::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
+    /// use rust_bert::pipelines::generation_utils::{
+    ///     GenerateConfig, GenerateOptions, LanguageGenerator,
+    /// };
     /// use tch::Tensor;
     /// # let mut home: PathBuf = dirs::home_dir().unwrap();
     /// # home.push("rustbert");
@@ -1681,7 +1686,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     ///
     /// let output = gpt2_generator.generate_indices(
     ///     Some(vec![input_context, second_input_context]),
-    ///     Some(generate_options)
+    ///     Some(generate_options),
     /// );
     /// # Ok(())
     /// # }
@@ -1740,7 +1745,9 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// # use tch::Device;
     /// # fn main() -> anyhow::Result<()> {
     /// use rust_bert::gpt2::GPT2Generator;
-    /// use rust_bert::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
+    /// use rust_bert::pipelines::generation_utils::{
+    ///     GenerateConfig, GenerateOptions, LanguageGenerator,
+    /// };
     /// use tch::{Kind, Tensor};
     /// # let mut home: PathBuf = dirs::home_dir().unwrap();
     /// # home.push("rustbert");
@@ -1752,8 +1759,8 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// let device = Device::cuda_if_available();
     ///
     /// let gpt2_generator = GPT2Generator::new(Default::default())?;
-    /// let input_tensor = Tensor::randn(&[32,128], (Kind::Int64, Device::Cpu));
-    /// let input_mask = Tensor::ones(&[32,128], (Kind::Int64, Device::Cpu));
+    /// let input_tensor = Tensor::randn(&[32, 128], (Kind::Int64, Device::Cpu));
+    /// let input_mask = Tensor::ones(&[32, 128], (Kind::Int64, Device::Cpu));
     ///
     /// let generate_options = GenerateOptions {
     ///     min_length: Some(32),
@@ -1765,7 +1772,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     /// let output = gpt2_generator.generate_from_ids_and_past(
     ///     input_tensor,
     ///     Some(input_mask),
-    ///     Some(generate_options)
+    ///     Some(generate_options),
     /// );
     /// # Ok(())
     /// # }

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -62,7 +62,7 @@
 //! # ;
 //! ```
 
-use tch::{Device, Tensor};
+use tch::Device;
 
 use crate::bart::{
     BartConfigResources, BartGenerator, BartMergesResources, BartModelResources, BartVocabResources,
@@ -254,72 +254,28 @@ impl SummarizationOption {
     }
 
     /// Interface method to generate() of the particular models.
-    pub fn generate<'a, S>(
-        &self,
-        prompt_texts: Option<S>,
-        attention_mask: Option<Tensor>,
-    ) -> Vec<String>
+    pub fn generate<'a, S>(&self, prompt_texts: Option<S>) -> Vec<String>
     where
         S: AsRef<[&'a str]>,
     {
         match *self {
             Self::Bart(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::ProphetNet(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::Pegasus(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
@@ -411,17 +367,15 @@ impl SummarizationModel {
         S: AsRef<[&'a str]>,
     {
         match &self.prefix {
-            None => self.model.generate(Some(texts), None),
+            None => self.model.generate(Some(texts)),
             Some(prefix) => {
                 let texts = texts
                     .as_ref()
                     .iter()
                     .map(|text| format!("{}{}", prefix, text))
                     .collect::<Vec<String>>();
-                self.model.generate(
-                    Some(texts.iter().map(|x| &**x).collect::<Vec<&str>>()),
-                    None,
-                )
+                self.model
+                    .generate(Some(texts.iter().map(|x| &**x).collect::<Vec<&str>>()))
             }
         }
     }

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -254,7 +254,7 @@ impl SummarizationOption {
     }
 
     /// Interface method to generate() of the particular models.
-    pub fn generate<'a, S>(&self, prompt_texts: Option<&[S]>) -> Vec<String>
+    pub fn generate<S>(&self, prompt_texts: Option<&[S]>) -> Vec<String>
     where
         S: AsRef<str> + Sync,
     {

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -260,22 +260,22 @@ impl SummarizationOption {
     {
         match *self {
             Self::Bart(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::ProphetNet(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::Pegasus(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -35,7 +35,7 @@ use crate::gpt_neo::GptNeoGenerator;
 use crate::openai_gpt::OpenAIGenerator;
 use crate::pipelines::common::{ModelType, TokenizerOption};
 use crate::pipelines::generation_utils::private_generation_utils::PrivateLanguageGenerator;
-use crate::pipelines::generation_utils::{GenerateConfig, LanguageGenerator};
+use crate::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
 use crate::reformer::ReformerGenerator;
 use crate::resources::Resource;
 use crate::xlnet::XLNetGenerator;
@@ -247,74 +247,34 @@ impl TextGenerationOption {
     where
         S: AsRef<[&'a str]>,
     {
+        let generate_options = Some(GenerateOptions {
+            min_length,
+            max_length,
+            ..Default::default()
+        });
         match *self {
             Self::GPT(ref model) => model
-                .generate_indices(
-                    prompt_texts,
-                    min_length,
-                    max_length,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_indices(prompt_texts, generate_options)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),
             Self::GPT2(ref model) => model
-                .generate_indices(
-                    prompt_texts,
-                    min_length,
-                    max_length,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_indices(prompt_texts, generate_options)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),
             Self::GPTNeo(ref model) => model
-                .generate_indices(
-                    prompt_texts,
-                    min_length,
-                    max_length,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_indices(prompt_texts, generate_options)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),
             Self::XLNet(ref model) => model
-                .generate_indices(
-                    prompt_texts,
-                    min_length,
-                    max_length,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_indices(prompt_texts, generate_options)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),
             Self::Reformer(ref model) => model
-                .generate_indices(
-                    prompt_texts,
-                    min_length,
-                    max_length,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate_indices(prompt_texts, generate_options)
                 .into_iter()
                 .map(|output| output.indices)
                 .collect(),

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -22,6 +22,13 @@
 //! - XLNet
 //! - Reformer
 //!
+//! Two APIs exist to build text generation models:
+//! - `TextGenerationModel` is a high-level module that exposes text generation capabilities with a set of reasonable defaults
+//! - the `LanguageGenerator` trait exposes lower-level text generation capabilities allowing the user to provide additional
+//! generation options when building the model (via `GenerateConfig`) and at each query (via `GenerateOptions`). Please check the
+//! [`generation_utils` module](../generation_utils/index.html) for more details
+//!
+//!
 //! Customized text generation models models can be loaded by overwriting the resources in the configuration.
 //! The dependencies will be downloaded to the user's home directory, e.g. under ~/.cache/.rustbert/gpt2
 use tch::Device;

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -24,7 +24,7 @@
 //!
 //! Customized text generation models models can be loaded by overwriting the resources in the configuration.
 //! The dependencies will be downloaded to the user's home directory, e.g. under ~/.cache/.rustbert/gpt2
-use tch::{Device, Tensor};
+use tch::Device;
 
 use crate::common::error::RustBertError;
 use crate::common::resources::RemoteResource;
@@ -241,7 +241,6 @@ impl TextGenerationOption {
     pub fn generate_indices<'a, S>(
         &self,
         prompt_texts: Option<S>,
-        attention_mask: Option<Tensor>,
         min_length: Option<i64>,
         max_length: Option<i64>,
     ) -> Vec<Vec<i64>>
@@ -252,7 +251,6 @@ impl TextGenerationOption {
             Self::GPT(ref model) => model
                 .generate_indices(
                     prompt_texts,
-                    attention_mask,
                     min_length,
                     max_length,
                     None,
@@ -267,7 +265,6 @@ impl TextGenerationOption {
             Self::GPT2(ref model) => model
                 .generate_indices(
                     prompt_texts,
-                    attention_mask,
                     min_length,
                     max_length,
                     None,
@@ -282,7 +279,6 @@ impl TextGenerationOption {
             Self::GPTNeo(ref model) => model
                 .generate_indices(
                     prompt_texts,
-                    attention_mask,
                     min_length,
                     max_length,
                     None,
@@ -297,7 +293,6 @@ impl TextGenerationOption {
             Self::XLNet(ref model) => model
                 .generate_indices(
                     prompt_texts,
-                    attention_mask,
                     min_length,
                     max_length,
                     None,
@@ -312,7 +307,6 @@ impl TextGenerationOption {
             Self::Reformer(ref model) => model
                 .generate_indices(
                     prompt_texts,
-                    attention_mask,
                     min_length,
                     max_length,
                     None,
@@ -431,7 +425,7 @@ with people, even a bishop, begging for his blessing. <eod> </s> <eos>"
             (None, None) => (None, None),
         };
         let generated_indices = match (prefix, prefix_length) {
-            (None, _) => self.model.generate_indices(Some(texts), None, None, None),
+            (None, _) => self.model.generate_indices(Some(texts), None, None),
             (Some(prefix), Some(prefix_length)) => {
                 let texts = texts
                     .as_ref()
@@ -440,7 +434,6 @@ with people, even a bishop, begging for his blessing. <eod> </s> <eos>"
                     .collect::<Vec<String>>();
                 self.model.generate_indices(
                     Some(texts.iter().map(|x| &**x).collect::<Vec<&str>>()),
-                    None,
                     Some(self.min_length + prefix_length),
                     Some(self.max_length + prefix_length),
                 )

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tch::{Device, Tensor};
+use tch::Device;
 
 use crate::common::error::RustBertError;
 use crate::common::resources::Resource;
@@ -733,7 +733,6 @@ impl TranslationOption {
     pub fn generate<'a, S>(
         &self,
         prompt_texts: Option<S>,
-        attention_mask: Option<Tensor>,
         forced_bos_token_id: Option<i64>,
     ) -> Vec<String>
     where
@@ -741,39 +740,18 @@ impl TranslationOption {
     {
         match *self {
             Self::Marian(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(
-                    prompt_texts,
-                    attention_mask,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                )
+                .generate(prompt_texts, None, None, None, None, None, None, false)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::MBart(ref model) => model
                 .generate(
                     prompt_texts,
-                    attention_mask,
                     None,
                     None,
                     None,
@@ -788,7 +766,6 @@ impl TranslationOption {
             Self::M2M100(ref model) => model
                 .generate(
                     prompt_texts,
-                    attention_mask,
                     None,
                     None,
                     None,
@@ -952,11 +929,10 @@ impl TranslationModel {
                     .collect::<Vec<String>>();
                 self.model.generate(
                     Some(texts.iter().map(AsRef::as_ref).collect::<Vec<&str>>()),
-                    None,
                     forced_bos_token_id,
                 )
             }
-            None => self.model.generate(Some(texts), None, forced_bos_token_id),
+            None => self.model.generate(Some(texts), forced_bos_token_id),
         })
     }
 }

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -20,7 +20,7 @@ use crate::marian::MarianGenerator;
 use crate::mbart::MBartGenerator;
 use crate::pipelines::common::ModelType;
 use crate::pipelines::generation_utils::private_generation_utils::PrivateLanguageGenerator;
-use crate::pipelines::generation_utils::{GenerateConfig, LanguageGenerator};
+use crate::pipelines::generation_utils::{GenerateConfig, GenerateOptions, LanguageGenerator};
 use crate::t5::T5Generator;
 use std::collections::HashSet;
 use std::fmt;
@@ -740,43 +740,37 @@ impl TranslationOption {
     {
         match *self {
             Self::Marian(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(prompt_texts, None, None, None, None, None, None, false)
+                .generate(prompt_texts, None)
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
-            Self::MBart(ref model) => model
-                .generate(
-                    prompt_texts,
-                    None,
-                    None,
-                    None,
+            Self::MBart(ref model) => {
+                let generate_options = GenerateOptions {
                     forced_bos_token_id,
-                    None,
-                    None,
-                    false,
-                )
-                .into_iter()
-                .map(|output| output.text)
-                .collect(),
-            Self::M2M100(ref model) => model
-                .generate(
-                    prompt_texts,
-                    None,
-                    None,
-                    None,
+                    ..Default::default()
+                };
+                model
+                    .generate(prompt_texts, Some(generate_options))
+                    .into_iter()
+                    .map(|output| output.text)
+                    .collect()
+            }
+            Self::M2M100(ref model) => {
+                let generate_options = GenerateOptions {
                     forced_bos_token_id,
-                    None,
-                    None,
-                    false,
-                )
-                .into_iter()
-                .map(|output| output.text)
-                .collect(),
+                    ..Default::default()
+                };
+                model
+                    .generate(prompt_texts, Some(generate_options))
+                    .into_iter()
+                    .map(|output| output.text)
+                    .collect()
+            }
         }
     }
 }

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -7,7 +7,7 @@ use rust_bert::pipelines::conversation::{
     ConversationConfig, ConversationManager, ConversationModel,
 };
 use rust_bert::pipelines::generation_utils::{
-    Cache, GenerateConfig, LMHeadModel, LanguageGenerator,
+    Cache, GenerateConfig, GenerateOptions, LMHeadModel, LanguageGenerator,
 };
 use rust_bert::pipelines::text_generation::{TextGenerationConfig, TextGenerationModel};
 use rust_bert::resources::{RemoteResource, Resource};
@@ -420,16 +420,16 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
 
     let input_context_1 = "Rust is a";
     let input_context_2 = "There was a ";
+
+    let generate_options = GenerateOptions {
+        prefix_allowed_tokens_fn: Some(&force_one_paragraph),
+        output_scores: true,
+        ..Default::default()
+    };
+
     let output = model.generate(
         Some(&[input_context_1, input_context_2]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&force_one_paragraph),
-        None,
-        true,
+        Some(generate_options),
     );
 
     assert_eq!(output.len(), 2);
@@ -487,29 +487,19 @@ fn gpt2_bad_tokens_greedy() -> anyhow::Result<()> {
 
     let input_context_1 = "Hello, my name is";
 
-    let baseline_output = model.generate(
-        Some(&[input_context_1]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        true,
-    );
+    let baseline_generate_options = GenerateOptions {
+        output_scores: true,
+        ..Default::default()
+    };
+    let test_generate_options = GenerateOptions {
+        bad_word_ids: Some(&bad_word_ids),
+        output_scores: true,
+        ..Default::default()
+    };
 
-    let output = model.generate(
-        Some(&[input_context_1]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&bad_word_ids),
-        true,
-    );
+    let baseline_output = model.generate(Some(&[input_context_1]), Some(baseline_generate_options));
+    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options));
+
     assert_eq!(baseline_output.len(), 1);
     assert_eq!(
         baseline_output[0].text,
@@ -567,29 +557,19 @@ fn gpt2_bad_tokens_beam_search() -> anyhow::Result<()> {
 
     let input_context_1 = "Hello, my name is";
 
-    let baseline_output = model.generate(
-        Some(&[input_context_1]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        true,
-    );
+    let baseline_generate_options = GenerateOptions {
+        output_scores: true,
+        ..Default::default()
+    };
+    let test_generate_options = GenerateOptions {
+        bad_word_ids: Some(&bad_word_ids),
+        output_scores: true,
+        ..Default::default()
+    };
 
-    let output = model.generate(
-        Some(&[input_context_1]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&bad_word_ids),
-        true,
-    );
+    let baseline_output = model.generate(Some(&[input_context_1]), Some(baseline_generate_options));
+    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options));
+
     assert_eq!(baseline_output.len(), 1);
     assert_eq!(
         baseline_output[0].text,
@@ -649,16 +629,16 @@ fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
 
     let input_context_1 = "Rust is a";
     let input_context_2 = "There was a ";
+
+    let generate_options = GenerateOptions {
+        prefix_allowed_tokens_fn: Some(&force_one_paragraph),
+        output_scores: true,
+        ..Default::default()
+    };
+
     let output = model.generate(
         Some(&[input_context_1, input_context_2]),
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(&force_one_paragraph),
-        None,
-        true,
+        Some(generate_options),
     );
 
     assert_eq!(output.len(), 2);


### PR DESCRIPTION
- Expose additional generation options on an instantiated model. When these optional `GenerateOptions` are provided, they take precedence over the configuration passed at model creation

Fixes https://github.com/guillaume-be/rust-bert/issues/186