### PR TITLE
Fix broken link by adding scheme to URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ model for predictions
 - French <-> German
 
 For languages not supported by the proposed pretrained Marian models, the user can leverage a M2M100 model supporting direct translation between 100 languages (without intermediate English translation)
-The full list of supported languages is available in the [crate documentation](docs.rs/rust-bert/0.15.1/rust_bert/pipelines/translation/enum.Language.html)
+The full list of supported languages is available in the [crate documentation](https://docs.rs/rust-bert/latest/rust_bert/pipelines/translation/enum.Language.html)
 
  ```rust
  use rust_bert::pipelines::translation::{Language, TranslationModelBuilder};


### PR DESCRIPTION
The current link, when clicked in the GitHub view of the readme, will
try to take you to
`https://github.com/guillaume-be/rust-bert/blob/master/docs.rs/rust-bert/0.15.1/rust_bert/pipelines/translation/enum.Language.html`,
which 404s.

Adding the `https://` scheme fixes this.

While adding the scheme, I also updated the docs.rs link to point to the
`latest` version of rust-bert.