### PR TITLE
Handle empty generation inputs

### DIFF
--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1751,8 +1751,10 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         };
 
         let input_ids = match prompt_texts {
-            Some(text) => self.encode_prompt_text(text, encoding_max_len, pad_token_id),
-            None => match self.get_bos_id() {
+            Some(prompts) if prompts.len() > 0 => {
+                self.encode_prompt_text(prompts, encoding_max_len, pad_token_id)
+            }
+            _ => match self.get_bos_id() {
                 Some(bos_id) => {
                     Tensor::ones(&[1, 1], (Int64, self.get_var_store().device())) * bos_id
                 }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1754,7 +1754,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             Some(prompts) if prompts.len() > 0 => {
                 self.encode_prompt_text(prompts, encoding_max_len, pad_token_id)
             }
-            _ => match self.get_bos_id() {
+            None => match self.get_bos_id() {
                 Some(bos_id) => {
                     Tensor::ones(&[1, 1], (Int64, self.get_var_store().device())) * bos_id
                 }
@@ -1762,6 +1762,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
                     "A model with a BOS token must be used to start generation with an empty input"
                 ),
             },
+            _ => return Vec::new(),
         };
         self.generate_from_ids_and_past(input_ids, None, generate_options)
     }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1751,7 +1751,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
         };
 
         let input_ids = match prompt_texts {
-            Some(prompts) if prompts.len() > 0 => {
+            Some(prompts) if !prompts.is_empty() => {
                 self.encode_prompt_text(prompts, encoding_max_len, pad_token_id)
             }
             None => match self.get_bos_id() {

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -1820,7 +1820,7 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
     fn generate_from_ids_and_past(
         &self,
         mut input_ids: Tensor,
-        attention_mask: Option<Tensor>,
+        mut attention_mask: Option<Tensor>,
         generate_options: Option<GenerateOptions>,
     ) -> Vec<GeneratedIndicesOutput> {
         let eos_token_ids = PrivateLanguageGenerator::get_eos_ids(self).cloned();
@@ -1867,6 +1867,10 @@ pub trait LanguageGenerator<T: LMHeadModel, V: Vocab, U: Tokenizer<V>>:
             ) * self
                 .get_bos_id()
                 .expect("`bos_token_id` has to be defined when no `input_ids` are provided.");
+            attention_mask = Some(Tensor::ones(
+                &[*input_id_size.first().unwrap(), 1],
+                (Int64, input_ids.device()),
+            ));
             input_ids_len += 1;
         }
 


### PR DESCRIPTION
Improve handling of empty inputs for text generation:
- Handle empty prompts list (return an empty vector)
- Handle list of zero-length (or space-only) inputs (pre-populate inputs with BOS token when available).

This behaviour matches the reference Python implementation.
Fixes https://github.com/guillaume-be/rust-bert/issues/267