### PR TITLE
Rust 1.63 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+## Changed
+- Addition of type aliases for the controlled generation (`PrefixAllowedFunction`) and zero-shot classification (`ZeroShotTemplate`)
+
 ## [0.18.0] - 2022-07-24
 ## Added
 - Support for sentence embeddings models and pipelines, based on [SentenceTransformers](https://www.sbert.net).

--- a/src/common/resources/local.rs
+++ b/src/common/resources/local.rs
@@ -3,7 +3,7 @@ use crate::resources::ResourceProvider;
 use std::path::PathBuf;
 
 /// # Local resource
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct LocalResource {
     /// Local path for the resource
     pub local_path: PathBuf,

--- a/src/common/resources/remote.rs
+++ b/src/common/resources/remote.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use std::path::PathBuf;
 
 /// # Remote resource that will be downloaded and cached locally on demand
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct RemoteResource {
     /// Remote path/url for the resource
     pub url: String,

--- a/src/deberta/deberta_model.rs
+++ b/src/deberta/deberta_model.rs
@@ -94,7 +94,7 @@ impl DebertaMergesResources {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 /// # Position attention type to use for the DeBERTa model.
 pub enum PositionAttentionType {
     p2c,

--- a/src/deberta_v2/deberta_v2_model.rs
+++ b/src/deberta_v2/deberta_v2_model.rs
@@ -105,7 +105,7 @@ pub struct DebertaV2Config {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 /// # Layer normalization layer for the DeBERTa model's relative embeddings.
 pub enum NormRelEmbedType {
     layer_norm,

--- a/src/gpt_neo/gpt_neo_model.rs
+++ b/src/gpt_neo/gpt_neo_model.rs
@@ -112,7 +112,7 @@ impl GptNeoMergesResources {
     );
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// #GPT-Neo attention layer type
 pub enum AttentionLayerType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,8 @@
 //!         "each sentence is converted"
 //!     ];
 //!     
-//!     let output = model.predict(&sentences);
+//!     let output = model.encode(&sentences);
+//! #   Ok(())
 //! # }
 //! ```
 //! Output:

--- a/src/pipelines/common.rs
+++ b/src/pipelines/common.rs
@@ -57,7 +57,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::path::Path;
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 /// # Identifies the type of model
 pub enum ModelType {
     Bart,

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -425,7 +425,8 @@
 //!         "each sentence is converted"
 //!     ];
 //!     
-//!     let output = model.predict(&sentences);
+//!     let output = model.encode(&sentences);
+//! #   Ok(())
 //! # }
 //! ```
 //! Output:

--- a/src/pipelines/sentiment.rs
+++ b/src/pipelines/sentiment.rs
@@ -60,7 +60,7 @@ use crate::pipelines::sequence_classification::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// Enum with the possible sentiment polarities. Note that the pre-trained SST2 model does not include neutral sentiment.
 pub enum SentimentPolarity {
     Positive,

--- a/src/pipelines/zero_shot_classification.rs
+++ b/src/pipelines/zero_shot_classification.rs
@@ -506,6 +506,26 @@ impl ZeroShotClassificationOption {
     }
 }
 
+pub type ZeroShotTemplate = Box<dyn Fn(&str) -> String>;
+/// Template used to transform the zero-shot classification labels into a set of
+/// natural language hypotheses for natural language inference.
+///
+/// For example, transform `[positive, negative]` into
+/// `[This is a positive review, This is a negative review]`
+///
+/// The function should take a `&str` as an input and return the formatted String.
+///
+/// This transformation has a strong impact on the resulting classification accuracy.
+/// If no function is provided for zero-shot classification, the default templating
+/// function will be used:
+///
+/// ```rust
+/// fn default_template(label: &str) -> String {
+///     format!("This example is about {}.", label)
+/// }
+/// ```
+///
+
 /// # ZeroShotClassificationModel for Zero Shot Classification
 pub struct ZeroShotClassificationModel {
     tokenizer: TokenizerOption,
@@ -567,7 +587,7 @@ impl ZeroShotClassificationModel {
         &self,
         inputs: S,
         labels: T,
-        template: Option<Box<dyn Fn(&str) -> String>>,
+        template: Option<ZeroShotTemplate>,
         max_len: usize,
     ) -> (Tensor, Tensor)
     where
@@ -691,7 +711,7 @@ impl ZeroShotClassificationModel {
         &self,
         inputs: S,
         labels: T,
-        template: Option<Box<dyn Fn(&str) -> String>>,
+        template: Option<ZeroShotTemplate>,
         max_length: usize,
     ) -> Vec<Label>
     where
@@ -832,7 +852,7 @@ impl ZeroShotClassificationModel {
         &self,
         inputs: S,
         labels: T,
-        template: Option<Box<dyn Fn(&str) -> String>>,
+        template: Option<ZeroShotTemplate>,
         max_length: usize,
     ) -> Vec<Vec<Label>>
     where

--- a/src/pipelines/zero_shot_classification.rs
+++ b/src/pipelines/zero_shot_classification.rs
@@ -524,7 +524,6 @@ pub type ZeroShotTemplate = Box<dyn Fn(&str) -> String>;
 ///     format!("This example is about {}.", label)
 /// }
 /// ```
-///
 
 /// # ZeroShotClassificationModel for Zero Shot Classification
 pub struct ZeroShotClassificationModel {


### PR DESCRIPTION
- Fixed additional Clippy warnings
- Introduction of type aliases for controlled generation (`PrefixAllowedTokensFunction`) and zero-shot templates (`ZeroShotTemplate`)
- Fixed doctests