### PR TITLE
Add checked prediction methods

### DIFF
--- a/examples/zero_shot_classification.rs
+++ b/examples/zero_shot_classification.rs
@@ -22,14 +22,16 @@ fn main() -> anyhow::Result<()> {
     let input_sequence_2 = "The prime minister has announced a stimulus package which was widely criticized by the opposition.";
     let candidate_labels = &["politics", "public health", "economy", "sports"];
 
-    let output = sequence_classification_model.predict_multilabel(
-        [input_sentence, input_sequence_2],
-        candidate_labels,
-        Some(Box::new(|label: &str| {
-            format!("This example is about {}.", label)
-        })),
-        128,
-    );
+    let output = sequence_classification_model
+        .predict_multilabel_checked(
+            [input_sentence, input_sequence_2],
+            candidate_labels,
+            Some(Box::new(|label: &str| {
+                format!("This example is about {}.", label)
+            })),
+            128,
+        )
+        .unwrap();
 
     println!("{:?}", output);
 


### PR DESCRIPTION
Add checked prediction methods to ZeroShotClassificationModel.
These methods return Option and convert any underlying errors into None,
to allow callers to implement appropriate error handling logic.

I named these methods `_checked` by analogy with `_unchecked` methods in [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.get_unchecked) and elsewhere in the standard library.

This closes #297 for ZeroShotClassificationModel.