### PR TITLE
Make predict methods in ZeroShot pipeline return Result instead of panicking on unwrap

### DIFF
--- a/examples/zero_shot_classification.rs
+++ b/examples/zero_shot_classification.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
     let candidate_labels = &["politics", "public health", "economy", "sports"];
 
     let output = sequence_classification_model
-        .predict_multilabel_checked(
+        .try_predict_multilabel(
             [input_sentence, input_sequence_2],
             candidate_labels,
             Some(Box::new(|label: &str| {

--- a/examples/zero_shot_classification.rs
+++ b/examples/zero_shot_classification.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
     let candidate_labels = &["politics", "public health", "economy", "sports"];
 
     let output = sequence_classification_model
-        .try_predict_multilabel(
+        .predict_multilabel(
             [input_sentence, input_sequence_2],
             candidate_labels,
             Some(Box::new(|label: &str| {

--- a/examples/zero_shot_classification.rs
+++ b/examples/zero_shot_classification.rs
@@ -22,14 +22,16 @@ fn main() -> anyhow::Result<()> {
     let input_sequence_2 = "The prime minister has announced a stimulus package which was widely criticized by the opposition.";
     let candidate_labels = &["politics", "public health", "economy", "sports"];
 
-    let output = sequence_classification_model.predict_multilabel(
-        [input_sentence, input_sequence_2],
-        candidate_labels,
-        Some(Box::new(|label: &str| {
-            format!("This example is about {}.", label)
-        })),
-        128,
-    );
+    let output = sequence_classification_model
+        .predict_multilabel_checked(
+            [input_sentence, input_sequence_2],
+            candidate_labels,
+            Some(Box::new(|label: &str| {
+                format!("This example is about {}.", label)
+            })),
+            128,
+        )
+        .unwrap();
 
     println!("{:?}", output);
 

--- a/src/pipelines/zero_shot_classification.rs
+++ b/src/pipelines/zero_shot_classification.rs
@@ -679,7 +679,7 @@ impl ZeroShotClassificationModel {
     /// let input_sequence_2 = "The prime minister has announced a stimulus package which was widely criticized by the opposition.";
     /// let candidate_labels = &["politics", "public health", "economics", "sports"];
     ///
-    /// let output = sequence_classification_model.predict(
+    /// let output = sequence_classification_model.try_predict(
     ///     &[input_sentence, input_sequence_2],
     ///     candidate_labels,
     ///     None,
@@ -708,7 +708,7 @@ impl ZeroShotClassificationModel {
     /// ]
     /// .to_vec());
     /// ```
-    pub fn predict_checked<'a, S, T>(
+    pub fn try_predict<'a, S, T>(
         &self,
         inputs: S,
         labels: T,
@@ -782,7 +782,7 @@ impl ZeroShotClassificationModel {
         S: AsRef<[&'a str]>,
         T: AsRef<[&'a str]>,
     {
-        self.predict_checked(inputs, labels, template, max_length)
+        self.try_predict(inputs, labels, template, max_length)
             .unwrap()
     }
 
@@ -811,7 +811,7 @@ impl ZeroShotClassificationModel {
     /// let input_sequence_2 = "The central bank is meeting today to discuss monetary policy.";
     /// let candidate_labels = &["politics", "public health", "economics", "sports"];
     ///
-    /// let output = sequence_classification_model.predict_multilabel_checked(
+    /// let output = sequence_classification_model.try_predict_multilabel(
     ///     &[input_sentence, input_sequence_2],
     ///     candidate_labels,
     ///     None,
@@ -879,7 +879,7 @@ impl ZeroShotClassificationModel {
     /// ]
     /// .to_vec());
     /// ```
-    pub fn predict_multilabel_checked<'a, S, T>(
+    pub fn try_predict_multilabel<'a, S, T>(
         &self,
         inputs: S,
         labels: T,
@@ -954,7 +954,7 @@ impl ZeroShotClassificationModel {
         S: AsRef<[&'a str]>,
         T: AsRef<[&'a str]>,
     {
-        self.predict_multilabel_checked(inputs, labels, template, max_length)
+        self.try_predict_multilabel(inputs, labels, template, max_length)
             .unwrap()
     }
 }

--- a/src/pipelines/zero_shot_classification.rs
+++ b/src/pipelines/zero_shot_classification.rs
@@ -708,7 +708,7 @@ impl ZeroShotClassificationModel {
     /// ]
     /// .to_vec());
     /// ```
-    pub fn try_predict<'a, S, T>(
+    pub fn predict<'a, S, T>(
         &self,
         inputs: S,
         labels: T,
@@ -762,28 +762,6 @@ impl ZeroShotClassificationModel {
             output_labels.push(label)
         }
         Ok(output_labels)
-    }
-
-    /// Exactly the same as [predict_checked](Self::predict_checked),
-    /// except it implicitly unwraps the result.
-    /// This used to be the default behavior, so this method is kept to preserve compatibility
-    /// with applications already relying on the result being implicitly unwrapped.
-    ///
-    /// New applications are encouraged to use [predict_checked](Self::predict_checked)
-    /// and implement appropriate error handling to reduce the possibility of panics at prediction time.
-    pub fn predict<'a, S, T>(
-        &self,
-        inputs: S,
-        labels: T,
-        template: Option<ZeroShotTemplate>,
-        max_length: usize,
-    ) -> Vec<Label>
-    where
-        S: AsRef<[&'a str]>,
-        T: AsRef<[&'a str]>,
-    {
-        self.try_predict(inputs, labels, template, max_length)
-            .unwrap()
     }
 
     /// Zero shot multi-label classification with 0, 1 or no true label.
@@ -879,7 +857,7 @@ impl ZeroShotClassificationModel {
     /// ]
     /// .to_vec());
     /// ```
-    pub fn try_predict_multilabel<'a, S, T>(
+    pub fn predict_multilabel<'a, S, T>(
         &self,
         inputs: S,
         labels: T,
@@ -934,28 +912,6 @@ impl ZeroShotClassificationModel {
             output_labels.push(sentence_labels);
         }
         Ok(output_labels)
-    }
-
-    /// Exactly the same as [predict_multilabel_checked](Self::predict_multilabel_checked),
-    /// except it implicitly unwraps the result.
-    /// This used to be the default behavior, so this method is kept to preserve compatibility
-    /// with applications already relying on the result being implicitly unwrapped.
-    ///
-    /// New applications are encouraged to use [predict_multilabel_checked](Self::predict_multilabel_checked)
-    /// and implement appropriate error handling to reduce the possibility of panics at prediction time.
-    pub fn predict_multilabel<'a, S, T>(
-        &self,
-        inputs: S,
-        labels: T,
-        template: Option<ZeroShotTemplate>,
-        max_length: usize,
-    ) -> Vec<Vec<Label>>
-    where
-        S: AsRef<[&'a str]>,
-        T: AsRef<[&'a str]>,
-    {
-        self.try_predict_multilabel(inputs, labels, template, max_length)
-            .unwrap()
     }
 }
 #[cfg(test)]

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -218,7 +218,7 @@ fn bart_zero_shot_classification() -> anyhow::Result<()> {
             format!("This example is about {}.", label)
         })),
         128,
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
 
@@ -240,7 +240,7 @@ fn bart_zero_shot_classification_try_error() -> anyhow::Result<()> {
     };
     let sequence_classification_model = ZeroShotClassificationModel::new(zero_shot_config)?;
 
-    let output = sequence_classification_model.try_predict(
+    let output = sequence_classification_model.predict(
         [],
         &[],
         Some(Box::new(|label: &str| {
@@ -279,7 +279,7 @@ fn bart_zero_shot_classification_multilabel() -> anyhow::Result<()> {
             format!("This example is about {}.", label)
         })),
         128,
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(output[0].len(), candidate_labels.len());
@@ -315,7 +315,7 @@ fn bart_zero_shot_classification_multilabel_try_error() -> anyhow::Result<()> {
     };
     let sequence_classification_model = ZeroShotClassificationModel::new(zero_shot_config)?;
 
-    let output = sequence_classification_model.try_predict_multilabel(
+    let output = sequence_classification_model.predict_multilabel(
         [],
         &[],
         Some(Box::new(|label: &str| {

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -232,7 +232,7 @@ fn bart_zero_shot_classification() -> anyhow::Result<()> {
 
 #[test]
 #[cfg_attr(not(feature = "all-tests"), ignore)]
-fn bart_zero_shot_classification_checked_error() -> anyhow::Result<()> {
+fn bart_zero_shot_classification_try_error() -> anyhow::Result<()> {
     //    Set-up model
     let zero_shot_config = ZeroShotClassificationConfig {
         device: Device::Cpu,
@@ -240,7 +240,7 @@ fn bart_zero_shot_classification_checked_error() -> anyhow::Result<()> {
     };
     let sequence_classification_model = ZeroShotClassificationModel::new(zero_shot_config)?;
 
-    let output = sequence_classification_model.predict_checked(
+    let output = sequence_classification_model.try_predict(
         [],
         &[],
         Some(Box::new(|label: &str| {
@@ -307,7 +307,7 @@ fn bart_zero_shot_classification_multilabel() -> anyhow::Result<()> {
 
 #[test]
 #[cfg_attr(not(feature = "all-tests"), ignore)]
-fn bart_zero_shot_classification_multilabel_checked_error() -> anyhow::Result<()> {
+fn bart_zero_shot_classification_multilabel_try_error() -> anyhow::Result<()> {
     //    Set-up model
     let zero_shot_config = ZeroShotClassificationConfig {
         device: Device::Cpu,
@@ -315,7 +315,7 @@ fn bart_zero_shot_classification_multilabel_checked_error() -> anyhow::Result<()
     };
     let sequence_classification_model = ZeroShotClassificationModel::new(zero_shot_config)?;
 
-    let output = sequence_classification_model.predict_multilabel_checked(
+    let output = sequence_classification_model.try_predict_multilabel(
         [],
         &[],
         Some(Box::new(|label: &str| {

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -242,7 +242,7 @@ fn bart_zero_shot_classification_try_error() -> anyhow::Result<()> {
 
     let output = sequence_classification_model.predict(
         [],
-        &[],
+        [],
         Some(Box::new(|label: &str| {
             format!("This example is about {}.", label)
         })),
@@ -317,7 +317,7 @@ fn bart_zero_shot_classification_multilabel_try_error() -> anyhow::Result<()> {
 
     let output = sequence_classification_model.predict_multilabel(
         [],
-        &[],
+        [],
         Some(Box::new(|label: &str| {
             format!("This example is about {}.", label)
         })),


### PR DESCRIPTION
Add checked prediction methods to ZeroShotClassificationModel.
These methods return `Result` to allow callers to implement appropriate error handling logic.

I named these methods `try_` by analogy with `try_` methods in [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_reserve) and elsewhere in the standard library.

This closes #297 for ZeroShotClassificationModel.