### PR TITLE
revert to windows 2019 pending 2022 fix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-windows:
     name: Build Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- revert to `windows-2019` pending resolution of regression introduced with Visual Studio 17.4 (shipping as a default with `windows-latest` or `windows-2022` (see https://developercommunity.visualstudio.com/t/thread_local-causing-fatal-error-LNK1161/10199441)