### PR TITLE
Update `cached-path` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ thiserror = "1.0.31"
 half = "2.1.0"
 regex = "1.6.0"
 
-cached-path = { version = "0.5.3", optional = true }
+cached-path = { version = "0.6.0", optional = true }
 dirs = { version = "4.0.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 


### PR DESCRIPTION
- Update `cached-path` dependency, allowing fore more transparent errors to address connectivity issues.

Fixes https://github.com/guillaume-be/rust-bert/issues/306