### PR TITLE
Permits TokenClassificationOption / DistilBertForTokenClassification to fail gracefully for an invalid configuration.

### DIFF
--- a/src/distilbert/distilbert_model.rs
+++ b/src/distilbert/distilbert_model.rs
@@ -696,7 +696,11 @@ impl DistilBertForTokenClassification {
         let num_labels = config
             .id2label
             .as_ref()
-            .ok_or_else(|| RustBertError::InvalidConfigurationError("id2label must be provided for classifiers".to_string()))?
+            .ok_or_else(|| {
+                RustBertError::InvalidConfigurationError(
+                    "id2label must be provided for classifiers".to_string(),
+                )
+            })?
             .len() as i64;
 
         let classifier = nn::linear(p / "classifier", config.dim, num_labels, Default::default());

--- a/src/distilbert/distilbert_model.rs
+++ b/src/distilbert/distilbert_model.rs
@@ -680,9 +680,12 @@ impl DistilBertForTokenClassification {
     /// let device = Device::Cpu;
     /// let p = nn::VarStore::new(device);
     /// let config = DistilBertConfig::from_file(config_path);
-    /// let distil_bert = DistilBertForTokenClassification::new(&p.root() / "distilbert", &config);
+    /// let distil_bert = DistilBertForTokenClassification::new(&p.root() / "distilbert", &config).unwrap();
     /// ```
-    pub fn new<'p, P>(p: P, config: &DistilBertConfig) -> DistilBertForTokenClassification
+    pub fn new<'p, P>(
+        p: P,
+        config: &DistilBertConfig,
+    ) -> Result<DistilBertForTokenClassification, RustBertError>
     where
         P: Borrow<nn::Path<'p>>,
     {
@@ -693,17 +696,17 @@ impl DistilBertForTokenClassification {
         let num_labels = config
             .id2label
             .as_ref()
-            .expect("id2label must be provided for classifiers")
+            .ok_or_else(|| RustBertError::InvalidConfigurationError("id2label must be provided for classifiers".to_string()))?
             .len() as i64;
 
         let classifier = nn::linear(p / "classifier", config.dim, num_labels, Default::default());
         let dropout = Dropout::new(config.seq_classif_dropout);
 
-        DistilBertForTokenClassification {
+        Ok(DistilBertForTokenClassification {
             distil_bert_model,
             classifier,
             dropout,
-        }
+        })
     }
 
     /// Forward pass through the model
@@ -735,7 +738,7 @@ impl DistilBertForTokenClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DistilBertConfig::from_file(config_path);
-    /// # let distilbert_model = DistilBertForTokenClassification::new(&vs.root(), &config);
+    /// # let distilbert_model = DistilBertForTokenClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));
@@ -793,6 +796,7 @@ pub struct DistilBertSequenceClassificationOutput {
     /// Attention weights for all intermediate layers
     pub all_attentions: Option<Vec<Tensor>>,
 }
+
 /// Container for the DistilBERT token classification model output
 pub struct DistilBertTokenClassificationOutput {
     /// Logits for each sequence item (token) for each target class
@@ -802,6 +806,7 @@ pub struct DistilBertTokenClassificationOutput {
     /// Attention weights for all intermediate layers
     pub all_attentions: Option<Vec<Tensor>>,
 }
+
 /// Container for the DistilBERT question answering model output
 pub struct DistilBertQuestionAnsweringOutput {
     /// Logits for the start position for token of each input sequence

--- a/src/fnet/fnet_model.rs
+++ b/src/fnet/fnet_model.rs
@@ -779,9 +779,12 @@ impl FNetForTokenClassification {
     /// let device = Device::Cpu;
     /// let p = nn::VarStore::new(device);
     /// let config = FNetConfig::from_file(config_path);
-    /// let fnet = FNetForTokenClassification::new(&p.root() / "fnet", &config);
+    /// let fnet = FNetForTokenClassification::new(&p.root() / "fnet", &config).unwrap();
     /// ```
-    pub fn new<'p, P>(p: P, config: &FNetConfig) -> FNetForTokenClassification
+    pub fn new<'p, P>(
+        p: P,
+        config: &FNetConfig,
+    ) -> Result<FNetForTokenClassification, RustBertError>
     where
         P: Borrow<nn::Path<'p>>,
     {
@@ -792,7 +795,11 @@ impl FNetForTokenClassification {
         let num_labels = config
             .id2label
             .as_ref()
-            .expect("num_labels not provided in configuration")
+            .ok_or_else(|| {
+                RustBertError::InvalidConfigurationError(
+                    "num_labels not provided in configuration".to_string(),
+                )
+            })?
             .len() as i64;
         let classifier = nn::linear(
             p / "classifier",
@@ -801,11 +808,11 @@ impl FNetForTokenClassification {
             Default::default(),
         );
 
-        FNetForTokenClassification {
+        Ok(FNetForTokenClassification {
             fnet,
             dropout,
             classifier,
-        }
+        })
     }
 
     /// Forward pass through the model
@@ -836,7 +843,7 @@ impl FNetForTokenClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForTokenClassification::new(&vs.root(), &config);
+    /// let model = FNetForTokenClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));
@@ -958,7 +965,7 @@ impl FNetForQuestionAnswering {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForTokenClassification::new(&vs.root(), &config);
+    /// let model = FNetForTokenClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));
@@ -1067,7 +1074,7 @@ mod test {
 
         //    Set-up masked LM model
         let device = Device::cuda_if_available();
-        let vs = tch::nn::VarStore::new(device);
+        let vs = nn::VarStore::new(device);
         let config = FNetConfig::from_file(config_path);
 
         let _: Box<dyn Send> = Box::new(FNetModel::new(vs.root(), &config, true));

--- a/src/fnet/fnet_model.rs
+++ b/src/fnet/fnet_model.rs
@@ -960,12 +960,12 @@ impl FNetForQuestionAnswering {
     /// # use rust_bert::Config;
     /// # use std::path::Path;
     /// # use tch::kind::Kind::Int64;
-    /// use rust_bert::fnet::{FNetConfig, FNetForTokenClassification};
+    /// use rust_bert::fnet::{FNetConfig, FNetForQuestionAnswering};
     /// # let config_path = Path::new("path/to/config.json");
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForTokenClassification::new(&vs.root(), &config).unwrap();
+    /// let model = FNetForQuestionAnswering::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/pipelines/token_classification.rs
+++ b/src/pipelines/token_classification.rs
@@ -354,7 +354,7 @@ impl TokenClassificationOption {
             ModelType::Bert => {
                 if let ConfigOption::Bert(config) = config {
                     Ok(TokenClassificationOption::Bert(
-                        BertForTokenClassification::new(p, config),
+                        BertForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -365,7 +365,7 @@ impl TokenClassificationOption {
             ModelType::Deberta => {
                 if let ConfigOption::Deberta(config) = config {
                     Ok(TokenClassificationOption::Deberta(
-                        DebertaForTokenClassification::new(p, config),
+                        DebertaForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -376,7 +376,7 @@ impl TokenClassificationOption {
             ModelType::DebertaV2 => {
                 if let ConfigOption::DebertaV2(config) = config {
                     Ok(TokenClassificationOption::DebertaV2(
-                        DebertaV2ForTokenClassification::new(p, config),
+                        DebertaV2ForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -387,7 +387,7 @@ impl TokenClassificationOption {
             ModelType::DistilBert => {
                 if let ConfigOption::DistilBert(config) = config {
                     Ok(TokenClassificationOption::DistilBert(
-                        DistilBertForTokenClassification::new(p, config),
+                        DistilBertForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -398,7 +398,7 @@ impl TokenClassificationOption {
             ModelType::MobileBert => {
                 if let ConfigOption::MobileBert(config) = config {
                     Ok(TokenClassificationOption::MobileBert(
-                        MobileBertForTokenClassification::new(p, config),
+                        MobileBertForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -409,7 +409,7 @@ impl TokenClassificationOption {
             ModelType::Roberta => {
                 if let ConfigOption::Roberta(config) = config {
                     Ok(TokenClassificationOption::Roberta(
-                        RobertaForTokenClassification::new(p, config),
+                        RobertaForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -420,7 +420,7 @@ impl TokenClassificationOption {
             ModelType::XLMRoberta => {
                 if let ConfigOption::Roberta(config) = config {
                     Ok(TokenClassificationOption::XLMRoberta(
-                        RobertaForTokenClassification::new(p, config),
+                        RobertaForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -431,7 +431,7 @@ impl TokenClassificationOption {
             ModelType::Electra => {
                 if let ConfigOption::Electra(config) = config {
                     Ok(TokenClassificationOption::Electra(
-                        ElectraForTokenClassification::new(p, config),
+                        ElectraForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -442,7 +442,7 @@ impl TokenClassificationOption {
             ModelType::Albert => {
                 if let ConfigOption::Albert(config) = config {
                     Ok(TokenClassificationOption::Albert(
-                        AlbertForTokenClassification::new(p, config),
+                        AlbertForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -453,7 +453,7 @@ impl TokenClassificationOption {
             ModelType::XLNet => {
                 if let ConfigOption::XLNet(config) = config {
                     Ok(TokenClassificationOption::XLNet(
-                        XLNetForTokenClassification::new(p, config).unwrap(),
+                        XLNetForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -464,7 +464,7 @@ impl TokenClassificationOption {
             ModelType::Longformer => {
                 if let ConfigOption::Longformer(config) = config {
                     Ok(TokenClassificationOption::Longformer(
-                        LongformerForTokenClassification::new(p, config),
+                        LongformerForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(
@@ -475,7 +475,7 @@ impl TokenClassificationOption {
             ModelType::FNet => {
                 if let ConfigOption::FNet(config) = config {
                     Ok(TokenClassificationOption::FNet(
-                        FNetForTokenClassification::new(p, config),
+                        FNetForTokenClassification::new(p, config)?,
                     ))
                 } else {
                     Err(RustBertError::InvalidConfigurationError(

--- a/src/xlnet/xlnet_model.rs
+++ b/src/xlnet/xlnet_model.rs
@@ -1080,7 +1080,7 @@ impl XLNetForTokenClassification {
     /// let device = Device::Cpu;
     /// let p = nn::VarStore::new(device);
     /// let config = XLNetConfig::from_file(config_path);
-    /// let xlnet_model = XLNetForTokenClassification::new(&p.root(), &config);
+    /// let xlnet_model = XLNetForTokenClassification::new(&p.root(), &config).unwrap();
     /// ```
     pub fn new<'p, P>(
         p: P,
@@ -1095,7 +1095,11 @@ impl XLNetForTokenClassification {
         let num_labels = config
             .id2label
             .as_ref()
-            .expect("num_labels not provided in configuration")
+            .ok_or_else(|| {
+                RustBertError::InvalidConfigurationError(
+                    "num_labels not provided in configuration".to_string(),
+                )
+            })?
             .len() as i64;
 
         let classifier = nn::linear(

--- a/tests/albert.rs
+++ b/tests/albert.rs
@@ -242,7 +242,7 @@ fn albert_for_token_classification() -> anyhow::Result<()> {
     config.id2label = Some(dummy_label_mapping);
     config.output_attentions = Some(true);
     config.output_hidden_states = Some(true);
-    let albert_model = AlbertForTokenClassification::new(vs.root(), &config);
+    let albert_model = AlbertForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let input = [

--- a/tests/bert.rs
+++ b/tests/bert.rs
@@ -309,7 +309,7 @@ fn bert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output =
-        no_grad(|| bert_model.forward_t(Some(&input_tensor), None, None, None, None, false));
+        no_grad(|| bert_model.unwrap().forward_t(Some(&input_tensor), None, None, None, None, false));
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);
     assert_eq!(

--- a/tests/bert.rs
+++ b/tests/bert.rs
@@ -308,8 +308,11 @@ fn bert_for_token_classification() -> anyhow::Result<()> {
     let input_tensor = Tensor::stack(tokenized_input.as_slice(), 0).to(device);
 
     //    Forward pass
-    let model_output =
-        no_grad(|| bert_model.unwrap().forward_t(Some(&input_tensor), None, None, None, None, false));
+    let model_output = no_grad(|| {
+        bert_model
+            .unwrap()
+            .forward_t(Some(&input_tensor), None, None, None, None, false)
+    });
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);
     assert_eq!(

--- a/tests/bert.rs
+++ b/tests/bert.rs
@@ -283,7 +283,7 @@ fn bert_for_token_classification() -> anyhow::Result<()> {
     config.id2label = Some(dummy_label_mapping);
     config.output_attentions = Some(true);
     config.output_hidden_states = Some(true);
-    let bert_model = BertForTokenClassification::new(vs.root(), &config);
+    let bert_model = BertForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let input = [
@@ -308,9 +308,8 @@ fn bert_for_token_classification() -> anyhow::Result<()> {
     let input_tensor = Tensor::stack(tokenized_input.as_slice(), 0).to(device);
 
     //    Forward pass
-    let model_output = no_grad(|| {
-        bert_model?.forward_t(Some(&input_tensor), None, None, None, None, false)
-    });
+    let model_output =
+        no_grad(|| bert_model.forward_t(Some(&input_tensor), None, None, None, None, false));
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);
     assert_eq!(

--- a/tests/bert.rs
+++ b/tests/bert.rs
@@ -309,9 +309,7 @@ fn bert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        bert_model
-            .unwrap()
-            .forward_t(Some(&input_tensor), None, None, None, None, false)
+        bert_model?.forward_t(Some(&input_tensor), None, None, None, None, false)
     });
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);

--- a/tests/deberta.rs
+++ b/tests/deberta.rs
@@ -170,7 +170,7 @@ fn deberta_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(2, String::from("PER"));
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
-    let model = DebertaForTokenClassification::new(vs.root(), &config);
+    let model = DebertaForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let inputs = ["Where's Paris?", "In Kentucky, United States"];

--- a/tests/deberta_v2.rs
+++ b/tests/deberta_v2.rs
@@ -142,7 +142,7 @@ fn deberta_v2_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(2, String::from("PER"));
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
-    let model = DebertaV2ForTokenClassification::new(vs.root(), &config);
+    let model = DebertaV2ForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let inputs = ["Where's Paris?", "In Kentucky, United States"];

--- a/tests/distilbert.rs
+++ b/tests/distilbert.rs
@@ -211,7 +211,7 @@ fn distilbert_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(2, String::from("PER"));
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
-    let distil_bert_model = DistilBertForTokenClassification::new(vs.root(), &config);
+    let distil_bert_model = DistilBertForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let input = [
@@ -237,7 +237,7 @@ fn distilbert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        distil_bert_model?
+        distil_bert_model
             .forward_t(Some(&input_tensor), None, None, false)
             .unwrap()
     });

--- a/tests/distilbert.rs
+++ b/tests/distilbert.rs
@@ -238,6 +238,7 @@ fn distilbert_for_token_classification() -> anyhow::Result<()> {
     //    Forward pass
     let model_output = no_grad(|| {
         distil_bert_model
+            .unwrap()
             .forward_t(Some(&input_tensor), None, None, false)
             .unwrap()
     });

--- a/tests/distilbert.rs
+++ b/tests/distilbert.rs
@@ -237,8 +237,7 @@ fn distilbert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        distil_bert_model
-            .unwrap()
+        distil_bert_model?
             .forward_t(Some(&input_tensor), None, None, false)
             .unwrap()
     });

--- a/tests/fnet.rs
+++ b/tests/fnet.rs
@@ -202,7 +202,7 @@ fn fnet_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
     config.output_hidden_states = Some(true);
-    let fnet_model = FNetForTokenClassification::new(vs.root(), &config);
+    let fnet_model = FNetForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let input = [
@@ -228,8 +228,9 @@ fn fnet_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        fnet_model?
-            .forward_t(Some(&input_tensor), None, None, None, false)?
+        fnet_model
+            .forward_t(Some(&input_tensor), None, None, None, false)
+            .unwrap()
     });
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);

--- a/tests/fnet.rs
+++ b/tests/fnet.rs
@@ -228,10 +228,8 @@ fn fnet_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        fnet_model
-            .unwrap()
-            .forward_t(Some(&input_tensor), None, None, None, false)
-            .unwrap()
+        fnet_model?
+            .forward_t(Some(&input_tensor), None, None, None, false)?
     });
 
     assert_eq!(model_output.logits.size(), &[2, 11, 4]);

--- a/tests/fnet.rs
+++ b/tests/fnet.rs
@@ -228,7 +228,8 @@ fn fnet_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        fnet_model.unwrap()
+        fnet_model
+            .unwrap()
             .forward_t(Some(&input_tensor), None, None, None, false)
             .unwrap()
     });

--- a/tests/fnet.rs
+++ b/tests/fnet.rs
@@ -121,6 +121,7 @@ fn fnet_for_sequence_classification() -> anyhow::Result<()> {
 
     Ok(())
 }
+
 //
 #[test]
 fn fnet_for_multiple_choice() -> anyhow::Result<()> {
@@ -227,7 +228,7 @@ fn fnet_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        fnet_model
+        fnet_model.unwrap()
             .forward_t(Some(&input_tensor), None, None, None, false)
             .unwrap()
     });

--- a/tests/longformer.rs
+++ b/tests/longformer.rs
@@ -337,7 +337,7 @@ fn longformer_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(2, String::from("PER"));
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
-    let model = LongformerForTokenClassification::new(vs.root(), &config);
+    let model = LongformerForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let inputs = ["Where's Paris?", "In Kentucky, United States"];

--- a/tests/mobilebert.rs
+++ b/tests/mobilebert.rs
@@ -240,7 +240,7 @@ fn mobilebert_for_token_classification() -> anyhow::Result<()> {
     dummy_label_mapping.insert(2, String::from("PER"));
     dummy_label_mapping.insert(3, String::from("ORG"));
     config.id2label = Some(dummy_label_mapping);
-    let model = MobileBertForTokenClassification::new(vs.root(), &config);
+    let model = MobileBertForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let inputs = ["Where's Paris?", "In Kentucky, United States"];
@@ -262,9 +262,8 @@ fn mobilebert_for_token_classification() -> anyhow::Result<()> {
     let input_tensor = Tensor::stack(tokenized_input.as_slice(), 0).to(device);
 
     //    Forward pass
-    let model_output = no_grad(|| {
-        model?.forward_t(Some(input_tensor.as_ref()), None, None, None, None, false)
-    })?;
+    let model_output =
+        no_grad(|| model.forward_t(Some(input_tensor.as_ref()), None, None, None, None, false))?;
 
     assert_eq!(model_output.logits.size(), &[2, 7, 4]);
 

--- a/tests/mobilebert.rs
+++ b/tests/mobilebert.rs
@@ -263,9 +263,7 @@ fn mobilebert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output = no_grad(|| {
-        model
-            .unwrap()
-            .forward_t(Some(input_tensor.as_ref()), None, None, None, None, false)
+        model?.forward_t(Some(input_tensor.as_ref()), None, None, None, None, false)
     })?;
 
     assert_eq!(model_output.logits.size(), &[2, 7, 4]);

--- a/tests/mobilebert.rs
+++ b/tests/mobilebert.rs
@@ -262,8 +262,11 @@ fn mobilebert_for_token_classification() -> anyhow::Result<()> {
     let input_tensor = Tensor::stack(tokenized_input.as_slice(), 0).to(device);
 
     //    Forward pass
-    let model_output =
-        no_grad(|| model.unwrap().forward_t(Some(input_tensor.as_ref()), None, None, None, None, false))?;
+    let model_output = no_grad(|| {
+        model
+            .unwrap()
+            .forward_t(Some(input_tensor.as_ref()), None, None, None, None, false)
+    })?;
 
     assert_eq!(model_output.logits.size(), &[2, 7, 4]);
 

--- a/tests/mobilebert.rs
+++ b/tests/mobilebert.rs
@@ -263,7 +263,7 @@ fn mobilebert_for_token_classification() -> anyhow::Result<()> {
 
     //    Forward pass
     let model_output =
-        no_grad(|| model.forward_t(Some(input_tensor.as_ref()), None, None, None, None, false))?;
+        no_grad(|| model.unwrap().forward_t(Some(input_tensor.as_ref()), None, None, None, None, false))?;
 
     assert_eq!(model_output.logits.size(), &[2, 7, 4]);
 

--- a/tests/roberta.rs
+++ b/tests/roberta.rs
@@ -273,7 +273,7 @@ fn roberta_for_token_classification() -> anyhow::Result<()> {
     config.id2label = Some(dummy_label_mapping);
     config.output_attentions = Some(true);
     config.output_hidden_states = Some(true);
-    let roberta_model = RobertaForTokenClassification::new(vs.root(), &config);
+    let roberta_model = RobertaForTokenClassification::new(vs.root(), &config)?;
 
     //    Define input
     let input = [


### PR DESCRIPTION
A production system shouldn't panic, if an invalid config is present. The implementation
is placed in a new method, so that the change is non-breaking.