### PR TITLE
0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## [0.20.0] - 2023-01-21
 ## Added
 - Addition of All-MiniLM-L6-V2 model weights
 - Addition of Keyword/Keyphrases extraction pipeline based on KeyBERT (https://github.com/MaartenGr/KeyBERT)
@@ -21,7 +22,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed configuration check for RoBERTa models for sentence classification.
 - Fixed a bug causing the input prompt to be truncated for text generation if the prompt length was longer than `max_length`
 
-## [0.18.0] - 2022-07-24
+## [0.19.0] - 2022-07-24
 ## Added
 - Support for sentence embeddings models and pipelines, based on [SentenceTransformers](https://www.sbert.net).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ lazy_static = { version = "1", optional = true }
 anyhow = "1"
 csv = "1"
 criterion = "0.4"
-tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
+tokio = { version = "1.24", features = ["sync", "rt-multi-thread", "macros"] }
 torch-sys = "=0.10.0"
 tempfile = "3"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "rust-bert"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Guillaume Becquin <guillaume.becquin@gmail.com>"]
 edition = "2018"
-description = "Ready-to-use NLP pipelines and transformer-based models (BERT, DistilBERT, GPT2,...)"
+description = "Ready-to-use NLP pipelines and language models"
 repository = "https://github.com/guillaume-be/rust-bert"
 documentation = "https://docs.rs/rust-bert"
 license = "Apache-2.0"
@@ -71,23 +71,23 @@ features = ["doc-only"]
 [dependencies]
 rust_tokenizers = "~7.0.2"
 tch = "~0.10.1"
-serde_json = "1.0.82"
-serde = { version = "1.0.140", features = ["derive"] }
-ordered-float = "3.0.0"
-uuid = { version = "1.1.2", features = ["v4"] }
-thiserror = "1.0.31"
-half = "2.1.0"
-regex = "1.6.0"
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+ordered-float = "3"
+uuid = { version = "1", features = ["v4"] }
+thiserror = "1"
+half = "2"
+regex = "1.6"
 
-cached-path = { version = "0.6.0", optional = true }
-dirs = { version = "4.0.0", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
+cached-path = { version = "0.6", optional = true }
+dirs = { version = "4", optional = true }
+lazy_static = { version = "1", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.58"
-csv = "1.1.6"
-criterion = "0.3.6"
-tokio = { version = "1.20.0", features = ["sync", "rt-multi-thread", "macros"] }
-torch-sys = "0.10.0"
-tempfile = "3.3.0"
-itertools = "0.10.3"
+anyhow = "1"
+csv = "1"
+criterion = "0.4"
+tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
+torch-sys = "=0.10.0"
+tempfile = "3"
+itertools = "0.10"

--- a/src/albert/albert_model.rs
+++ b/src/albert/albert_model.rs
@@ -572,7 +572,7 @@ impl AlbertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = AlbertConfig::from_file(config_path);
-    /// # let albert_model: AlbertForSequenceClassification = AlbertForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let albert_model: AlbertForSequenceClassification = AlbertForSequenceClassification::new(&vs.root(), &config).unwrap();
     ///  let (batch_size, sequence_length) = (64, 128);
     ///  let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     ///  let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/albert/albert_model.rs
+++ b/src/albert/albert_model.rs
@@ -572,7 +572,7 @@ impl AlbertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = AlbertConfig::from_file(config_path);
-    /// # let albert_model: AlbertForSequenceClassification = AlbertForSequenceClassification::new(&vs.root(), &config);
+    /// # let albert_model: AlbertForSequenceClassification = AlbertForSequenceClassification::new(&vs.root(), &config)?;
     ///  let (batch_size, sequence_length) = (64, 128);
     ///  let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     ///  let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/bart/bart_model.rs
+++ b/src/bart/bart_model.rs
@@ -829,7 +829,7 @@ impl BartForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = BartConfig::from_file(config_path);
-    /// # let bart_model: BartForSequenceClassification = BartForSequenceClassification::new(&vs.root(), &config);
+    /// # let bart_model: BartForSequenceClassification = BartForSequenceClassification::new(&vs.root(), &config).unwrap();;
     ///  let (batch_size, source_sequence_length, target_sequence_length) = (64, 128, 56);
     ///  let input_tensor = Tensor::rand(&[batch_size, source_sequence_length], (Int64, device));
     ///  let target_tensor = Tensor::rand(&[batch_size, target_sequence_length], (Int64, device));

--- a/src/bert/bert_model.rs
+++ b/src/bert/bert_model.rs
@@ -747,7 +747,7 @@ impl BertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = BertConfig::from_file(config_path);
-    /// # let bert_model = BertForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let bert_model = BertForSequenceClassification::new(&vs.root(), &config).unwrap();;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/bert/bert_model.rs
+++ b/src/bert/bert_model.rs
@@ -747,7 +747,7 @@ impl BertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = BertConfig::from_file(config_path);
-    /// # let bert_model = BertForSequenceClassification::new(&vs.root(), &config);
+    /// # let bert_model = BertForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/deberta/deberta_model.rs
+++ b/src/deberta/deberta_model.rs
@@ -805,7 +805,7 @@ impl DebertaForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DebertaConfig::from_file(config_path);
-    /// # let model = DebertaForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let model = DebertaForSequenceClassification::new(&vs.root(), &config).unwrap();;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/deberta/deberta_model.rs
+++ b/src/deberta/deberta_model.rs
@@ -805,7 +805,7 @@ impl DebertaForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DebertaConfig::from_file(config_path);
-    /// # let model = DebertaForSequenceClassification::new(&vs.root(), &config);
+    /// # let model = DebertaForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/deberta_v2/deberta_v2_model.rs
+++ b/src/deberta_v2/deberta_v2_model.rs
@@ -667,7 +667,7 @@ impl DebertaV2ForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DebertaV2Config::from_file(config_path);
-    /// # let model = DebertaV2ForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let model = DebertaV2ForSequenceClassification::new(&vs.root(), &config).unwrap();;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/deberta_v2/deberta_v2_model.rs
+++ b/src/deberta_v2/deberta_v2_model.rs
@@ -667,7 +667,7 @@ impl DebertaV2ForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DebertaV2Config::from_file(config_path);
-    /// # let model = DebertaV2ForSequenceClassification::new(&vs.root(), &config);
+    /// # let model = DebertaV2ForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Kind::Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Kind::Int64, device));

--- a/src/distilbert/distilbert_model.rs
+++ b/src/distilbert/distilbert_model.rs
@@ -356,7 +356,7 @@ impl DistilBertModelClassifier {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DistilBertConfig::from_file(config_path);
-    /// # let distilbert_model: DistilBertModelClassifier = DistilBertModelClassifier::new(&vs.root(), &config);
+    /// # let distilbert_model: DistilBertModelClassifier = DistilBertModelClassifier::new(&vs.root(), &config)?;
     ///  let (batch_size, sequence_length) = (64, 128);
     ///  let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     ///  let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/distilbert/distilbert_model.rs
+++ b/src/distilbert/distilbert_model.rs
@@ -356,7 +356,7 @@ impl DistilBertModelClassifier {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = DistilBertConfig::from_file(config_path);
-    /// # let distilbert_model: DistilBertModelClassifier = DistilBertModelClassifier::new(&vs.root(), &config)?;
+    /// # let distilbert_model: DistilBertModelClassifier = DistilBertModelClassifier::new(&vs.root(), &config).unwrap();;
     ///  let (batch_size, sequence_length) = (64, 128);
     ///  let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     ///  let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/fnet/fnet_model.rs
+++ b/src/fnet/fnet_model.rs
@@ -563,7 +563,7 @@ impl FNetForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForSequenceClassification::new(&vs.root(), &config);
+    /// let model = FNetForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));
@@ -972,7 +972,7 @@ impl FNetForQuestionAnswering {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForQuestionAnswering::new(&vs.root(), &config).unwrap();
+    /// let model = FNetForQuestionAnswering::new(&vs.root(), &config);
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/fnet/fnet_model.rs
+++ b/src/fnet/fnet_model.rs
@@ -563,7 +563,7 @@ impl FNetForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = FNetConfig::from_file(config_path);
-    /// let model = FNetForSequenceClassification::new(&vs.root(), &config)?;
+    /// let model = FNetForSequenceClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let token_type_ids = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/longformer/longformer_model.rs
+++ b/src/longformer/longformer_model.rs
@@ -925,7 +925,7 @@ impl LongformerForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = LongformerConfig::from_file(config_path);
-    /// let longformer_model = LongformerForSequenceClassification::new(&vs.root(), &config)?;
+    /// let longformer_model = LongformerForSequenceClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length, target_sequence_length) = (64, 128, 32);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let attention_mask = Tensor::ones(&[batch_size, sequence_length], (Int64, device));

--- a/src/longformer/longformer_model.rs
+++ b/src/longformer/longformer_model.rs
@@ -925,7 +925,7 @@ impl LongformerForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = LongformerConfig::from_file(config_path);
-    /// let longformer_model = LongformerForSequenceClassification::new(&vs.root(), &config);
+    /// let longformer_model = LongformerForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length, target_sequence_length) = (64, 128, 32);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let attention_mask = Tensor::ones(&[batch_size, sequence_length], (Int64, device));

--- a/src/mbart/mbart_model.rs
+++ b/src/mbart/mbart_model.rs
@@ -652,7 +652,7 @@ impl MBartForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = MBartConfig::from_file(config_path);
-    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config).unwrap();;
     ///  let (batch_size, source_sequence_length, target_sequence_length) = (64, 128, 56);
     ///  let input_tensor = Tensor::rand(&[batch_size, source_sequence_length], (Int64, device));
     ///  let target_tensor = Tensor::rand(&[batch_size, target_sequence_length], (Int64, device));

--- a/src/mbart/mbart_model.rs
+++ b/src/mbart/mbart_model.rs
@@ -652,7 +652,7 @@ impl MBartForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = MBartConfig::from_file(config_path);
-    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config);
+    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config)?;
     ///  let (batch_size, source_sequence_length, target_sequence_length) = (64, 128, 56);
     ///  let input_tensor = Tensor::rand(&[batch_size, source_sequence_length], (Int64, device));
     ///  let target_tensor = Tensor::rand(&[batch_size, target_sequence_length], (Int64, device));

--- a/src/mobilebert/mobilebert_model.rs
+++ b/src/mobilebert/mobilebert_model.rs
@@ -755,7 +755,7 @@ impl MobileBertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = MobileBertConfig::from_file(config_path);
-    /// let model = MobileBertForSequenceClassification::new(&vs.root(), &config);
+    /// let model = MobileBertForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let attention_mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/mobilebert/mobilebert_model.rs
+++ b/src/mobilebert/mobilebert_model.rs
@@ -755,7 +755,7 @@ impl MobileBertForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = MobileBertConfig::from_file(config_path);
-    /// let model = MobileBertForSequenceClassification::new(&vs.root(), &config)?;
+    /// let model = MobileBertForSequenceClassification::new(&vs.root(), &config).unwrap();
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let attention_mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/pipelines/masked_language.rs
+++ b/src/pipelines/masked_language.rs
@@ -491,7 +491,7 @@ impl MaskedLanguageModel {
     /// ];
     ///
     /// //    Run model
-    /// let output = mask_language_model.predict(&input);
+    /// let output = mask_language_model.predict(&input)?;
     /// for word in output {
     ///     println!("{:?}", word);
     /// }

--- a/src/roberta/roberta_model.rs
+++ b/src/roberta/roberta_model.rs
@@ -549,7 +549,7 @@ impl RobertaForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = BertConfig::from_file(config_path);
-    /// # let roberta_model = RobertaForSequenceClassification::new(&vs.root(), &config)?;
+    /// # let roberta_model = RobertaForSequenceClassification::new(&vs.root(), &config).unwrap();;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));

--- a/src/roberta/roberta_model.rs
+++ b/src/roberta/roberta_model.rs
@@ -549,7 +549,7 @@ impl RobertaForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = BertConfig::from_file(config_path);
-    /// # let roberta_model = RobertaForSequenceClassification::new(&vs.root(), &config);
+    /// # let roberta_model = RobertaForSequenceClassification::new(&vs.root(), &config)?;
     /// let (batch_size, sequence_length) = (64, 128);
     /// let input_tensor = Tensor::rand(&[batch_size, sequence_length], (Int64, device));
     /// let mask = Tensor::zeros(&[batch_size, sequence_length], (Int64, device));


### PR DESCRIPTION
## Added
- Addition of All-MiniLM-L6-V2 model weights
- Addition of Keyword/Keyphrases extraction pipeline based on KeyBERT (https://github.com/MaartenGr/KeyBERT)
- Addition of Masked Language Model pipeline, allowing to predict masked words.
- Support for the CodeBERT language model with pretrained models for language detection and masked token prediction

## Changed
- Addition of type aliases for the controlled generation (`PrefixAllowedFunction`) and zero-shot classification (`ZeroShotTemplate`).
- (BREAKING) `merges_resource` now optional for all pipelines.
- Allow mixing local and remote resources in pipelines.
- Upgraded to `torch` 1.13 (via `tch` 0.9.0).
- (BREAKING) Made the `max_length` argument for generation methods and pipelines optional.
- (BREAKING) Changed return type of `ModelForSequenceClassification` and `ModelForTokenClassification` to `Result<Self, RustBertError>` allowing error handling if no labels are provided in the configuration.

## Fixed
- Fixed configuration check for RoBERTa models for sentence classification.
- Fixed a bug causing the input prompt to be truncated for text generation if the prompt length was longer than `max_length`

Fixes https://github.com/guillaume-be/rust-bert/issues/240, https://github.com/guillaume-be/rust-bert/issues/312