### PR TITLE
Generalize input of NERModel::predict_full_entities

### DIFF
--- a/src/pipelines/ner.rs
+++ b/src/pipelines/ner.rs
@@ -274,7 +274,10 @@ impl NERModel {
     /// ]]
     /// # ;
     /// ```
-    pub fn predict_full_entities(&self, input: &[&str]) -> Vec<Vec<Entity>> {
+    pub fn predict_full_entities<S>(&self, input: &[S]) -> Vec<Vec<Entity>>
+    where
+        S: AsRef<str>,
+    {
         let tokens = self.token_classification_model.predict(input, true, false);
         let mut entities: Vec<Vec<Entity>> = Vec::new();
 


### PR DESCRIPTION
Make the input parameter of `pipelines::ner::NERModel::predict_full_entities` as generic as `NERModel::predict`.