### PR TITLE
Fix sentence embeddings example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Generate sentence embeddings (vector representation). These can be used for appl
         "each sentence is converted"
     ];
     
-    let output = model.predict(&sentences);
+    let output = model.encode(&sentences)?;
 ```
 Output:
 ```


### PR DESCRIPTION
Two changes:

1. Method name is `encode`, not `predict`
2. Add a `?` operator for consistency with `create_model()?`