### PR TITLE
convert_model.py add support for multiple binary files

### DIFF
--- a/utils/convert_model.py
+++ b/utils/convert_model.py
@@ -10,7 +10,7 @@ from torch import Tensor
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "source_file", help="Absolute path to the Pytorch weights file to convert"
+        "source_file", nargs="+", help="Absolute path to the Pytorch weights file to convert"
     )
     parser.add_argument(
         "--skip_embeddings",
@@ -32,40 +32,41 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    source_file = Path(args.source_file)
-    target_folder = source_file.parent
-
-    weights = torch.load(str(source_file), map_location="cpu")
-
     nps = {}
-    for k, v in weights.items():
-        k = k.replace("gamma", "weight").replace("beta", "bias")
-        if args.skip_embeddings:
-            if k in {
-                "model.encoder.embed_tokens.weight",
-                "encoder.embed_tokens.weight",
-                "model.decoder.embed_tokens.weight",
-                "decoder.embed_tokens.weight",
-            }:
-                continue
-        if args.skip_lm_head:
-            if k in {
-                "lm_head.weight",
-            }:
-                continue
-        if args.prefix:
-            k = args.prefix + k
-        if args.suffix:
-            k = k.split(".")[-1]
-        if isinstance(v, Tensor):
-            tensor = v.cpu().numpy()
-            if args.dtype is not None:
-                nps[k] = np.ascontiguousarray(tensor.astype(np.dtype(args.dtype)))
+    target_folder = Path(args.source_file[0]).parent
+
+    for source_file in args.source_file:
+        source_file = Path(source_file)
+        weights = torch.load(str(source_file), map_location="cpu")
+        
+        for k, v in weights.items():
+            k = k.replace("gamma", "weight").replace("beta", "bias")
+            if args.skip_embeddings:
+                if k in {
+                    "model.encoder.embed_tokens.weight",
+                    "encoder.embed_tokens.weight",
+                    "model.decoder.embed_tokens.weight",
+                    "decoder.embed_tokens.weight",
+                }:
+                    continue
+            if args.skip_lm_head:
+                if k in {
+                    "lm_head.weight",
+                }:
+                    continue
+            if args.prefix:
+                k = args.prefix + k
+            if args.suffix:
+                k = k.split(".")[-1]
+            if isinstance(v, Tensor):
+                tensor = v.cpu().numpy()
+                if args.dtype is not None:
+                    nps[k] = np.ascontiguousarray(tensor.astype(np.dtype(args.dtype)))
+                else:
+                    nps[k] = np.ascontiguousarray(tensor)
+                print(f"converted {k} - {str(sys.getsizeof(nps[k]))} bytes")
             else:
-                nps[k] = np.ascontiguousarray(tensor)
-            print(f"converted {k} - {str(sys.getsizeof(nps[k]))} bytes")
-        else:
-            print(f"skipped non-tensor object: {k}")
+                print(f"skipped non-tensor object: {k}")
     np.savez(target_folder / "model.npz", **nps)
 
     source = str(target_folder / "model.npz")


### PR DESCRIPTION
Allows to provide multiple binary file paths to the convert_model.py script to merge them into one binary file.

I tried to use pygmalion-6b with rust-bert but could not figure out how to use multiple model files, so I instead opted to create one large binary file using the convert_model.py script.

The odd & unsafe looking `target_folder = Path(args.source_file[0]).parent` should be safe as `nargs="+"` should guarantee that at least one option/file is provided.