### PR TITLE
Remove pooler from BERT for Masked LM architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Fixed
 - MIN/MAX computation for float-like (was set to infinity instead of min/max)
+- Remove the (unused) pooler from the set of weights for BERT Masked LM architecture
 
 ## [0.20.0] - 2023-01-21
 ## Added

--- a/src/bert/bert_model.rs
+++ b/src/bert/bert_model.rs
@@ -559,7 +559,7 @@ impl BertForMaskedLM {
     {
         let p = p.borrow();
 
-        let bert = BertModel::new(p / "bert", config);
+        let bert = BertModel::new_with_optional_pooler(p / "bert", config, false);
         let cls = BertLMPredictionHead::new(p / "cls", config);
 
         BertForMaskedLM { bert, cls }


### PR DESCRIPTION
- Update BertForMaskedLM constructor to build the base model without pooler, mirroring the behaviour of the [Python implmentation](https://github.com/huggingface/transformers/blob/656e869a4523f6a0ce90b3aacbb05cc8fb5794bb/src/transformers/models/bert/modeling_bert.py#L1314)

Fixes https://github.com/guillaume-be/rust-bert/issues/349