### PR TITLE
fix issue where device selection was lost when creating remote model

### DIFF
--- a/src/pipelines/sentence_embeddings/builder.rs
+++ b/src/pipelines/sentence_embeddings/builder.rs
@@ -179,6 +179,8 @@ impl SentenceEmbeddingsBuilder<Remote> {
     }
 
     pub fn create_model(self) -> Result<SentenceEmbeddingsModel, RustBertError> {
-        SentenceEmbeddingsModel::new(self.inner.config)
+        let mut config = self.inner.config;
+        config.device = self.device;
+        SentenceEmbeddingsModel::new(config)
     }
 }

--- a/src/pipelines/sentence_embeddings/builder.rs
+++ b/src/pipelines/sentence_embeddings/builder.rs
@@ -178,9 +178,8 @@ impl SentenceEmbeddingsBuilder<Remote> {
         self
     }
 
-    pub fn create_model(self) -> Result<SentenceEmbeddingsModel, RustBertError> {
-        let mut config = self.inner.config;
-        config.device = self.device;
+    pub fn create_model(mut self) -> Result<SentenceEmbeddingsModel, RustBertError> {
+        self.inner.config.device = self.device;
         SentenceEmbeddingsModel::new(config)
     }
 }

--- a/src/pipelines/sentence_embeddings/builder.rs
+++ b/src/pipelines/sentence_embeddings/builder.rs
@@ -180,6 +180,6 @@ impl SentenceEmbeddingsBuilder<Remote> {
 
     pub fn create_model(mut self) -> Result<SentenceEmbeddingsModel, RustBertError> {
         self.inner.config.device = self.device;
-        SentenceEmbeddingsModel::new(config)
+        SentenceEmbeddingsModel::new(self.inner.config)
     }
 }


### PR DESCRIPTION
Device selection on sentence embeddings builder was being lost when creating the model. This fix mirrors what's done on the local model builder. 