### PR TITLE
Add custom tokenizer option for pipelines, extend tokenizer interface methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 ## Added
 - Addition of the [LongT5](https://arxiv.org/abs/2112.07916) model architecture and pretrained weights.
+- Addition of `add_tokens` and `add_extra_ids` interafce methods to the `TokenizerOption`. Allow building most pipeline with custom tokenizer via `new_with_tokenizer`.
 
 ## Changed
 - Bumped the tokenizers dependency from 7.x to 8.x, exposing additional options for special token mapping and adding the NLLBTokenizer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ remote = ["cached-path", "dirs", "lazy_static"]
 features = ["doc-only"]
 
 [dependencies]
-rust_tokenizers = "8.0.0"
+rust_tokenizers = "8.1"
 tch = "0.11.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/pipelines/common.rs
+++ b/src/pipelines/common.rs
@@ -1792,4 +1792,54 @@ impl TokenizerOption {
             Self::OpenAiGpt(_) => None,
         }
     }
+
+    /// Interface method
+    pub fn add_extra_ids(&mut self, num_extra_ids: i64) {
+        match *self {
+            Self::Bert(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Deberta(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::DebertaV2(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Roberta(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Bart(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Marian(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::T5(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::XLMRoberta(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Albert(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::XLNet(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::GPT2(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::OpenAiGpt(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Reformer(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::ProphetNet(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::Pegasus(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::MBart50(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::M2M100(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::NLLB(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+            Self::FNet(ref mut tokenizer) => tokenizer.add_extra_ids(num_extra_ids),
+        }
+    }
+
+    /// Interface method
+    pub fn add_tokens(&mut self, tokens: &[&str]) {
+        match *self {
+            Self::Bert(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Deberta(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::DebertaV2(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Roberta(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Bart(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Marian(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::T5(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::XLMRoberta(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Albert(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::XLNet(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::GPT2(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::OpenAiGpt(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Reformer(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::ProphetNet(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::Pegasus(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::MBart50(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::M2M100(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::NLLB(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+            Self::FNet(ref mut tokenizer) => tokenizer.add_tokens(tokens),
+        }
+    }
 }

--- a/src/pipelines/masked_language.rs
+++ b/src/pipelines/masked_language.rs
@@ -380,15 +380,12 @@ impl MaskedLanguageModel {
     /// # }
     /// ```
     pub fn new(config: MaskedLanguageConfig) -> Result<MaskedLanguageModel, RustBertError> {
-        let config_path = config.config_resource.get_local_path()?;
         let vocab_path = config.vocab_resource.get_local_path()?;
-        let weights_path = config.model_resource.get_local_path()?;
-        let merges_path = if let Some(merges_resource) = &config.merges_resource {
-            Some(merges_resource.get_local_path()?)
-        } else {
-            None
-        };
-        let device = config.device;
+        let merges_path = config
+            .merges_resource
+            .as_ref()
+            .map(|resource| resource.get_local_path())
+            .transpose()?;
 
         let tokenizer = TokenizerOption::from_file(
             config.model_type,
@@ -398,6 +395,42 @@ impl MaskedLanguageModel {
             config.strip_accents,
             config.add_prefix_space,
         )?;
+        Self::new_with_tokenizer(config, tokenizer)
+    }
+
+    /// Build a new `MaskedLanguageModel` with a provided tokenizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - `MaskedLanguageConfig` object containing the resource references (model, vocabulary, configuration) and device placement (CPU/GPU)
+    /// * `tokenizer` - `TokenizerOption` tokenizer to use for masked language modeling
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// use rust_bert::pipelines::common::{ModelType, TokenizerOption};
+    /// use rust_bert::pipelines::masked_language::MaskedLanguageModel;
+    /// let tokenizer = TokenizerOption::from_file(
+    ///     ModelType::Bert,
+    ///     "path/to/vocab.txt",
+    ///     None,
+    ///     false,
+    ///     None,
+    ///     None,
+    /// )?;
+    /// let model = MaskedLanguageModel::new_with_tokenizer(Default::default(), tokenizer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_with_tokenizer(
+        config: MaskedLanguageConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<MaskedLanguageModel, RustBertError> {
+        let config_path = config.config_resource.get_local_path()?;
+        let weights_path = config.model_resource.get_local_path()?;
+        let device = config.device;
+
         let mut var_store = VarStore::new(device);
         let model_config = ConfigOption::from_file(config.model_type, config_path);
         let max_length = model_config

--- a/src/pipelines/ner.rs
+++ b/src/pipelines/ner.rs
@@ -127,6 +127,7 @@
 //! Dutch| XLM_ROBERTA_NER_NL |
 
 use crate::common::error::RustBertError;
+use crate::pipelines::common::TokenizerOption;
 use crate::pipelines::token_classification::{
     Token, TokenClassificationConfig, TokenClassificationModel,
 };
@@ -173,6 +174,41 @@ impl NERModel {
     /// ```
     pub fn new(ner_config: NERConfig) -> Result<NERModel, RustBertError> {
         let model = TokenClassificationModel::new(ner_config)?;
+        Ok(NERModel {
+            token_classification_model: model,
+        })
+    }
+
+    /// Build a new `NERModel` with a provided tokenizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `ner_config` - `NERConfig` object containing the resource references (model, vocabulary, configuration) and device placement (CPU/GPU)
+    /// * `tokenizer` - `TokenizerOption` tokenizer to use for token classification
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// use rust_bert::pipelines::common::{ModelType, TokenizerOption};
+    /// use rust_bert::pipelines::ner::NERModel;
+    /// let tokenizer = TokenizerOption::from_file(
+    ///     ModelType::Bert,
+    ///     "path/to/vocab.txt",
+    ///     None,
+    ///     false,
+    ///     None,
+    ///     None,
+    /// )?;
+    /// let ner_model = NERModel::new_with_tokenizer(Default::default(), tokenizer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_with_tokenizer(
+        ner_config: NERConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<NERModel, RustBertError> {
+        let model = TokenClassificationModel::new_with_tokenizer(ner_config, tokenizer)?;
         Ok(NERModel {
             token_classification_model: model,
         })

--- a/src/pipelines/pos_tagging.rs
+++ b/src/pipelines/pos_tagging.rs
@@ -85,6 +85,7 @@ use crate::common::error::RustBertError;
 use crate::pipelines::token_classification::{TokenClassificationConfig, TokenClassificationModel};
 use serde::{Deserialize, Serialize};
 
+use crate::pipelines::common::TokenizerOption;
 #[cfg(feature = "remote")]
 use {
     crate::{
@@ -171,6 +172,41 @@ impl POSModel {
     /// ```
     pub fn new(pos_config: POSConfig) -> Result<POSModel, RustBertError> {
         let model = TokenClassificationModel::new(pos_config.into())?;
+        Ok(POSModel {
+            token_classification_model: model,
+        })
+    }
+
+    /// Build a new `POSModel` with a provided tokenizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `pos_config` - `POSConfig` object containing the resource references (model, vocabulary, configuration) and device placement (CPU/GPU)
+    /// * `tokenizer` - `TokenizerOption` tokenizer to use for POS tagging.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// use rust_bert::pipelines::common::{ModelType, TokenizerOption};
+    /// use rust_bert::pipelines::pos_tagging::POSModel;
+    /// let tokenizer = TokenizerOption::from_file(
+    ///     ModelType::Bert,
+    ///     "path/to/vocab.txt",
+    ///     None,
+    ///     false,
+    ///     None,
+    ///     None,
+    /// )?;
+    /// let pos_model = POSModel::new_with_tokenizer(Default::default(), tokenizer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_with_tokenizer(
+        pos_config: POSConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<POSModel, RustBertError> {
+        let model = TokenClassificationModel::new_with_tokenizer(pos_config.into(), tokenizer)?;
         Ok(POSModel {
             token_classification_model: model,
         })

--- a/src/pipelines/sentiment.rs
+++ b/src/pipelines/sentiment.rs
@@ -55,6 +55,7 @@
 //! ```
 
 use crate::common::error::RustBertError;
+use crate::pipelines::common::TokenizerOption;
 use crate::pipelines::sequence_classification::{
     SequenceClassificationConfig, SequenceClassificationModel,
 };
@@ -102,6 +103,42 @@ impl SentimentModel {
     /// ```
     pub fn new(sentiment_config: SentimentConfig) -> Result<SentimentModel, RustBertError> {
         let sequence_classification_model = SequenceClassificationModel::new(sentiment_config)?;
+        Ok(SentimentModel {
+            sequence_classification_model,
+        })
+    }
+
+    /// Build a new `SentimentModel` with a provided tokenizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `sentiment_config` - `SentimentConfig` object containing the resource references (model, vocabulary, configuration) and device placement (CPU/GPU)
+    /// * `tokenizer` - `TokenizerOption` tokenizer to use for sentiment classification.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// use rust_bert::pipelines::common::{ModelType, TokenizerOption};
+    /// use rust_bert::pipelines::sentiment::SentimentModel;
+    /// let tokenizer = TokenizerOption::from_file(
+    ///     ModelType::Bert,
+    ///     "path/to/vocab.txt",
+    ///     None,
+    ///     false,
+    ///     None,
+    ///     None,
+    /// )?;
+    /// let sentiment_model = SentimentModel::new_with_tokenizer(Default::default(), tokenizer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_with_tokenizer(
+        sentiment_config: SentimentConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<SentimentModel, RustBertError> {
+        let sequence_classification_model =
+            SequenceClassificationModel::new_with_tokenizer(sentiment_config, tokenizer)?;
         Ok(SentimentModel {
             sequence_classification_model,
         })

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -1152,6 +1152,35 @@ impl TranslationOption {
         }
     }
 
+    pub fn new_with_tokenizer(
+        config: TranslationConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<Self, RustBertError> {
+        match config.model_type {
+            ModelType::Marian => Ok(TranslationOption::Marian(
+                MarianGenerator::new_with_tokenizer(config.into(), tokenizer)?,
+            )),
+            ModelType::T5 => Ok(TranslationOption::T5(T5Generator::new_with_tokenizer(
+                config.into(),
+                tokenizer,
+            )?)),
+            ModelType::MBart => Ok(TranslationOption::MBart(
+                MBartGenerator::new_with_tokenizer(config.into(), tokenizer)?,
+            )),
+            ModelType::M2M100 => Ok(TranslationOption::M2M100(
+                M2M100Generator::new_with_tokenizer(config.into(), tokenizer)?,
+            )),
+            ModelType::NLLB => Ok(TranslationOption::NLLB(NLLBGenerator::new_with_tokenizer(
+                config.into(),
+                tokenizer,
+            )?)),
+            _ => Err(RustBertError::InvalidConfigurationError(format!(
+                "Translation not implemented for {:?}!",
+                config.model_type
+            ))),
+        }
+    }
+
     /// Returns the `ModelType` for this TranslationOption
     pub fn model_type(&self) -> ModelType {
         match *self {
@@ -1422,6 +1451,74 @@ impl TranslationModel {
         let supported_target_languages = translation_config.target_languages.clone();
 
         let model = TranslationOption::new(translation_config)?;
+
+        Ok(TranslationModel {
+            model,
+            supported_source_languages,
+            supported_target_languages,
+        })
+    }
+
+    /// Build a new `TranslationModel` with a provided tokenizer.
+    ///
+    /// # Arguments
+    ///
+    /// * `translation_config` - `TranslationConfig` object containing the resource references (model, vocabulary, configuration), translation options and device placement (CPU/GPU)
+    /// * `tokenizer` - `TokenizerOption` tokenizer to use for translation
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {     ///
+    /// use rust_bert::marian::{
+    ///     MarianConfigResources, MarianModelResources, MarianSourceLanguages, MarianSpmResources,
+    ///     MarianTargetLanguages, MarianVocabResources,
+    /// };
+    /// use rust_bert::pipelines::common::{ModelType, TokenizerOption};
+    /// use rust_bert::pipelines::translation::{TranslationConfig, TranslationModel};
+    /// use rust_bert::resources::{RemoteResource, ResourceProvider};
+    /// use tch::Device;
+    ///
+    /// let model_resource = RemoteResource::from_pretrained(MarianModelResources::ROMANCE2ENGLISH);
+    /// let config_resource = RemoteResource::from_pretrained(MarianConfigResources::ROMANCE2ENGLISH);
+    /// let vocab_resource = RemoteResource::from_pretrained(MarianVocabResources::ROMANCE2ENGLISH);
+    /// let spm_resource = RemoteResource::from_pretrained(MarianSpmResources::ROMANCE2ENGLISH);
+    ///
+    /// let tokenizer = TokenizerOption::from_file(
+    ///     ModelType::Marian,
+    ///     vocab_resource.get_local_path()?.to_str()?,
+    ///     Some(spm_resource.get_local_path()?.to_str()?),
+    ///     false,
+    ///     None,
+    ///     None,
+    /// )?;
+    ///
+    /// let source_languages = MarianSourceLanguages::ROMANCE2ENGLISH;
+    /// let target_languages = MarianTargetLanguages::ROMANCE2ENGLISH;
+    ///
+    /// let translation_config = TranslationConfig::new(
+    ///     ModelType::Marian,
+    ///     model_resource,
+    ///     config_resource,
+    ///     vocab_resource,
+    ///     Some(spm_resource),
+    ///     source_languages,
+    ///     target_languages,
+    ///     Device::cuda_if_available(),
+    /// );
+    /// let mut summarization_model =
+    ///     TranslationModel::new_with_tokenizer(translation_config, tokenizer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_with_tokenizer(
+        translation_config: TranslationConfig,
+        tokenizer: TokenizerOption,
+    ) -> Result<TranslationModel, RustBertError> {
+        let supported_source_languages = translation_config.source_languages.clone();
+        let supported_target_languages = translation_config.target_languages.clone();
+
+        let model = TranslationOption::new_with_tokenizer(translation_config, tokenizer)?;
 
         Ok(TranslationModel {
             model,

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -1486,8 +1486,8 @@ impl TranslationModel {
     ///
     /// let tokenizer = TokenizerOption::from_file(
     ///     ModelType::Marian,
-    ///     vocab_resource.get_local_path()?.to_str()?,
-    ///     Some(spm_resource.get_local_path()?.to_str()?),
+    ///     vocab_resource.get_local_path()?.to_str().unwrap(),
+    ///     Some(spm_resource.get_local_path()?.to_str().unwrap()),
     ///     false,
     ///     None,
     ///     None,

--- a/tests/nllb.rs
+++ b/tests/nllb.rs
@@ -25,7 +25,7 @@ fn nllb_translation() -> anyhow::Result<()> {
         Some(merges_resource),
         source_languages,
         target_languages,
-        Device::cuda_if_available(),
+        Device::Cpu,
     );
     let model = TranslationModel::new(translation_config)?;
 


### PR DESCRIPTION
- Addition of `add_tokens` and `add_extra_ids` interafce methods to the `TokenizerOption`. 
- Allow building most pipeline with custom tokenizer via `new_with_tokenizer`.

Relates to https://github.com/guillaume-be/rust-bert/issues/343