### PR TITLE
fix typo in `SentenceEmbeddingsTokenizerOuput`

### DIFF
--- a/src/pipelines/sentence_embeddings/mod.rs
+++ b/src/pipelines/sentence_embeddings/mod.rs
@@ -42,7 +42,7 @@ pub use config::{
 };
 pub use pipeline::{
     SentenceEmbeddingsModel, SentenceEmbeddingsModelOutput, SentenceEmbeddingsOption,
-    SentenceEmbeddingsTokenizerOuput,
+    SentenceEmbeddingsTokenizerOutput,
 };
 
 pub use resources::{

--- a/src/pipelines/sentence_embeddings/pipeline.rs
+++ b/src/pipelines/sentence_embeddings/pipeline.rs
@@ -283,7 +283,7 @@ impl SentenceEmbeddingsModel {
     }
 
     /// Tokenizes the inputs
-    pub fn tokenize<S>(&self, inputs: &[S]) -> SentenceEmbeddingsTokenizerOuput
+    pub fn tokenize<S>(&self, inputs: &[S]) -> SentenceEmbeddingsTokenizerOutput
     where
         S: AsRef<str> + Sync,
     {
@@ -327,7 +327,7 @@ impl SentenceEmbeddingsModel {
             .map(|input| Tensor::of_slice(&(input)))
             .collect::<Vec<_>>();
 
-        SentenceEmbeddingsTokenizerOuput {
+        SentenceEmbeddingsTokenizerOutput {
             tokens_ids,
             tokens_masks,
         }
@@ -341,7 +341,7 @@ impl SentenceEmbeddingsModel {
     where
         S: AsRef<str> + Sync,
     {
-        let SentenceEmbeddingsTokenizerOuput {
+        let SentenceEmbeddingsTokenizerOutput {
             tokens_ids,
             tokens_masks,
         } = self.tokenize(inputs);
@@ -457,7 +457,7 @@ impl SentenceEmbeddingsModel {
 }
 
 /// Container for the SentenceEmbeddings tokenizer output.
-pub struct SentenceEmbeddingsTokenizerOuput {
+pub struct SentenceEmbeddingsTokenizerOutput {
     pub tokens_ids: Vec<Tensor>,
     pub tokens_masks: Vec<Tensor>,
 }


### PR DESCRIPTION
I've missed this typo in my previous PR. Doesn't seem there are any other similar typos.