### PR TITLE
Fix `download-libtorch` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ default = ["remote"]
 doc-only = ["tch/doc-only"]
 all-tests = []
 remote = ["cached-path", "dirs", "lazy_static"]
-download-libtorch = ["torch-sys/download-libtorch"]
+download-libtorch = ["tch/download-libtorch"]
 
 [package.metadata.docs.rs]
 features = ["doc-only"]


### PR DESCRIPTION
- Pass on the `download-libtorch` to `tch` rather than `torch-sys`