### PR TITLE
Reexport TLS options from `cached-path`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,14 @@ harness = false
 opt-level = 3
 
 [features]
-default = ["remote"]
+default = ["remote", "default-tls"]
 doc-only = ["tch/doc-only"]
 all-tests = []
 remote = ["cached-path", "dirs", "lazy_static"]
 download-libtorch = ["tch/download-libtorch"]
 onnx = ["ort", "ndarray"]
+rustls-tls = ["cached-path/rustls-tls"]
+default-tls = ["cached-path/default-tls"]
 
 [package.metadata.docs.rs]
 features = ["doc-only"]
@@ -82,7 +84,7 @@ thiserror = "1"
 half = "2"
 regex = "1.6"
 
-cached-path = { version = "0.6", optional = true }
+cached-path = { version = "0.6", default-features = false, optional = true }
 dirs = { version = "4", optional = true }
 lazy_static = { version = "1", optional = true }
 ort = {version="1.14.8", optional = true, default-features = false, features = ["half"]}


### PR DESCRIPTION
This change allows for users of `rust-bert` to use `reqwest` with Rustls instead of OpenSSL by reexporting the `cached-path` feature flags (which are reexported from `reqwest`).

OpenSSL is still used by default; specifying nothing results in the same set of features that are used before this change.