### PR TITLE
Add a Dockerfile build for the converter only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM rust:1.72.0 as builder
+
+
+RUN apt update && apt full-upgrade -y && apt install python3 python3-pip -y && apt autoremove -y
+# Install libtorch
+RUN pip3 install torch==2.0.0 --break-system-packages
+
+WORKDIR /app
+
+COPY src src
+COPY benches benches
+COPY build.rs build.rs
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+ENV LIBTORCH_USE_PYTORCH=1
+RUN cargo build --release --bin convert-tensor
+
+# # ============
+
+FROM python:3.11-slim 
+
+COPY --from=builder /app/target/release/convert-tensor .
+
+RUN apt update && apt full-upgrade -y && apt install libgomp1 && apt autoremove -y
+
+RUN pip3 install torch==2.0.0 numpy==1.26.0 --break-system-packages
+
+COPY utils utils
+
+ENV ON_DOCKER=1
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/torch/lib
+
+ENTRYPOINT [ "python3", "./utils/convert_model.py"]
+

--- a/utils/convert_model.py
+++ b/utils/convert_model.py
@@ -48,6 +48,8 @@ import logging
 import subprocess
 import sys
 import zipfile
+import os
+
 from pathlib import Path
 from typing import Dict
 
@@ -178,16 +180,25 @@ if __name__ == "__main__":
     source = str(target_folder / "model.npz")
     target = str(target_folder / "rust_model.ot")
 
-    toml_location = (Path(__file__).resolve() / ".." / ".." / "Cargo.toml").resolve()
-    cargo_args = [
-        "cargo",
-        "run",
-        "--bin=convert-tensor",
-        "--manifest-path=%s" % toml_location,
-        "--",
-        source,
-        target,
-    ]
-    if args.download_libtorch:
-        cargo_args += ["--features", "download-libtorch"]
+    if os.environ["ON_DOCKER"]:
+        cargo_args = [
+            "/convert-tensor",
+            source,
+            target,
+        ]
+    else:
+        toml_location = (
+            Path(__file__).resolve() / ".." / ".." / "Cargo.toml"
+        ).resolve()
+        cargo_args = [
+            "cargo",
+            "run",
+            "--bin=convert-tensor",
+            "--manifest-path=%s" % toml_location,
+            "--",
+            source,
+            target,
+        ]
+        if args.download_libtorch:
+            cargo_args += ["--features", "download-libtorch"]
     subprocess.run(cargo_args)


### PR DESCRIPTION
Currently, converting an existing HF model requires having (1) a Rust environment ready, (2) `rust-bert` repo available and, (3) setting up a Python environment, just for the conversion.

For the use case where 

(a) a Rust developer wants to utilize an HF model, they would need a Python environment
(b) a data scientist wants to experiment with different models, and a given Rust project that was created for them by Rust devs: they would need a Rust environment, and to set up a `rust-bert` repo

As it seems, the groups are mostly mutually exclusive.

I've created a Dockerfile, which I think is minimal, that only does the conversion. It:

1. Builds the Rust project
2. Sets up a python environment with the prebuilt Rust converter
3. Takes a conversion command

And so, developers and data scientists need only to depend on Docker, and assuming the image is called `rustbert-converter` after it was built to only run:

`docker run -v "$(pwd)"/<path to model on host>:/model rustbert-converter pytorch_mode.bin`

The image expects a `/model` folder which is shared between the container and the host, where the raw pytorch model files are.
