### PR TITLE
bump tch and torch-sys to 0.14.0; fixes win64 build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ features = ["doc-only"]
 
 [dependencies]
 rust_tokenizers = "8.1"
-tch = "0.13.0"
+tch = "0.14.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "3"
@@ -97,7 +97,7 @@ anyhow = "1"
 csv = "1"
 criterion = "0.4"
 tokio = { version = "1.24", features = ["sync", "rt-multi-thread", "macros"] }
-torch-sys = "0.13.0"
+torch-sys = "0.14.0"
 tempfile = "3"
 itertools = "0.10"
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "env-filter", "fmt" ] }


### PR DESCRIPTION
I was not having success with rust-bert.  I tried downloading tch-rs and all the examples worked.

rust-bert was giving me the following `fatal error C1189: #error:  You need C++17 to compile PyTorch`
```
cargo run --example --example conversation
   Compiling torch-sys v0.13.0
The following warnings were emitted during compilation:

warning: ToolExecError: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api.o" "-c" "libtch/torch_api.cpp" with args "cl.exe" did not execute successfully (status code exit code: 2).
warning: ToolExecError: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api_generated.o" "-c" "libtch/torch_api_generated.cpp" with args "cl.exe" did not execute successfully (status code exit code: 2).

error: failed to run custom build command for `torch-sys v0.13.0`

Caused by:
  process didn't exit successfully: `c:\working\rust\rust-bert\target\debug\build\torch-sys-605e4a7b06f1f208\build-script-build` (exit code: 1)
  --- stdout
  cargo:rerun-if-env-changed=LIBTORCH_USE_PYTORCH
  cargo:rerun-if-env-changed=LIBTORCH
  cargo:rerun-if-env-changed=LIBTORCH_INCLUDE
  cargo:rerun-if-env-changed=LIBTORCH_LIB
  cargo:rerun-if-env-changed=LIBTORCH_CXX11_ABI
  cargo:rerun-if-env-changed=LIBTORCH_STATIC
  cargo:rustc-link-search=native=C:\working\cpp\libtorch\libtorch\lib
  cargo:rerun-if-changed=libtch/dummy_cuda_dependency.cpp
  cargo:rerun-if-changed=libtch/torch_python.cpp
  cargo:rerun-if-changed=libtch/torch_python.h
  cargo:rerun-if-changed=libtch/torch_api_generated.cpp
  cargo:rerun-if-changed=libtch/torch_api_generated.h
  cargo:rerun-if-changed=libtch/torch_api.cpp
  cargo:rerun-if-changed=libtch/torch_api.h
  cargo:rerun-if-changed=libtch/stb_image_write.h
  cargo:rerun-if-changed=libtch/stb_image_resize.h
  cargo:rerun-if-changed=libtch/stb_image.h
  TARGET = Some("x86_64-pc-windows-msvc")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-pc-windows-msvc")
  cargo:rerun-if-env-changed=CXX_x86_64-pc-windows-msvc
  CXX_x86_64-pc-windows-msvc = None
  cargo:rerun-if-env-changed=CXX_x86_64_pc_windows_msvc
  CXX_x86_64_pc_windows_msvc = None
  cargo:rerun-if-env-changed=HOST_CXX
  HOST_CXX = None
  cargo:rerun-if-env-changed=CXX
  CXX = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
  DEBUG = Some("true")
  cargo:rerun-if-env-changed=CXXFLAGS_x86_64-pc-windows-msvc
  CXXFLAGS_x86_64-pc-windows-msvc = None
  cargo:rerun-if-env-changed=CXXFLAGS_x86_64_pc_windows_msvc
  CXXFLAGS_x86_64_pc_windows_msvc = None
  cargo:rerun-if-env-changed=HOST_CXXFLAGS
  HOST_CXXFLAGS = None
  cargo:rerun-if-env-changed=CXXFLAGS
  CXXFLAGS = None
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api.o" "-c" "libtch/torch_api.cpp"
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api_generated.o" "-c" "libtch/torch_api_generated.cpp"
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/dummy_cuda_dependency.o" "-c" "libtch/dummy_cuda_dependency.cpp"
  torch_api.cpp
  torch_api_generated.cpp
  dummy_cuda_dependency.cpp
  libtch/dummy_cuda_dependency.cpp(20): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
  C:\working\cpp\libtorch\libtorch\include\c10/util/C++17.h(27): fatal error C1189: #error:  You need C++17 to compile PyTorch
  C:\working\cpp\libtorch\libtorch\include\c10/util/C++17.h(27): fatal error C1189: #error:  You need C++17 to compile PyTorch
  exit code: 2
  cargo:warning=ToolExecError: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api.o" "-c" "libtch/torch_api.cpp" with args "cl.exe" did not execute successfully (status code exit code: 2).
  exit code: 2
  cargo:warning=ToolExecError: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api_generated.o" "-c" "libtch/torch_api_generated.cpp" with args "cl.exe" did not execute successfully (status code exit code: 2).
  exit code: 0

  --- stderr


  error occurred: Command "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MD" "-Z7" "-Brepro" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include" "-I" "C:\\working\\cpp\\libtorch\\libtorch\\include/torch/csrc/api/include" "-Foc:\\working\\rust\\rust-bert\\target\\debug\\build\\torch-sys-b34e14c01f15d1bd\\out\\libtch/torch_api_generated.o" "-c" "libtch/torch_api_generated.cpp" with args "cl.exe" did not execute successfully (status code exit code: 2).
```

I updated Cargo.toml to 0.14 and all the examples are working.
For this Win64 install, a bump of torch-sys and tch were required for me.

```
cargo run --example --example conversation
    Updating crates.io index
  Downloaded torch-sys v0.14.0
  Downloaded tch v0.14.0
  Downloaded 2 crates (1.7 MB) in 0.97s (largest was `tch` at 1.4 MB)
   Compiling torch-sys v0.14.0
   Compiling tch v0.14.0
   Compiling rust-bert v0.21.0 (C:\working\rust\rust-bert)
warning: call to `.borrow()` on a reference in this situation does nothing
   --> src\models\mbart\mbart_model.rs:453:43
    |
453 |         let base_model = MBartModel::new(p.borrow() / "model", config);
    |                                           ^^^^^^^^^ help: remove this redundant call
    |
    = note: the type `tch::nn::Path<'_>` does not implement `Borrow`, so calling `borrow` on `&tch::nn::Path<'_>` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default

warning: `rust-bert` (lib) generated 1 warning (run `cargo fix --lib -p rust-bert` to apply 1 suggestion)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 12s
     Running `target\debug\examples\conversation.exe`
```
thanks for the code.
