### PR TITLE
`tch 0.14.0` update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Added
 - Addition of `new_with_tokenizer` constructor for `SentenceEmbeddingsModel` allowing passing custom tokenizers for sentence embeddings pipelines.
 - Support for [Tokenizers](https://github.com/huggingface/tokenizers) in pipelines, allowing loading `tokenizer.json` and `special_token_map.json` tokenizer files. 
-- Most model configuration can now take an optional `kind` parameter to specify the model weight precision. If not provided, will default to full precision on CPU, or the serialized weights precision otherwise.
+- (BREAKING) Most model configuration can now take an optional `kind` parameter to specify the model weight precision. If not provided, will default to full precision on CPU, or the serialized weights precision otherwise.
 
 ## Fixed
 - (BREAKING) Fixed the keyword extraction pipeline for n-gram sizes > 2. Add new configuration option `tokenizer_forbidden_ngram_chars` to specify characters that should be excluded from n-grams (allows filtering m-grams spanning multiple sentences).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file. The format 
 ## Added
 - Addition of `new_with_tokenizer` constructor for `SentenceEmbeddingsModel` allowing passing custom tokenizers for sentence embeddings pipelines.
 - Support for [Tokenizers](https://github.com/huggingface/tokenizers) in pipelines, allowing loading `tokenizer.json` and `special_token_map.json` tokenizer files. 
+- Most model configuration can now take an optional `kind` parameter to specify the model weight precision. If not provided, will default to full precision on CPU, or the serialized weights precision otherwise.
 
 ## Fixed
 - (BREAKING) Fixed the keyword extraction pipeline for n-gram sizes > 2. Add new configuration option `tokenizer_forbidden_ngram_chars` to specify characters that should be excluded from n-grams (allows filtering m-grams spanning multiple sentences).
 - Improved MPS device compatibility setting the `sparse_grad` flag to false for `gather` operations
 - Updated ONNX runtime backend version to 1.15.x
 - Issue with incorrect results for QA models with a tokenizer not using segment ids
+- Issue with GPT-J that was incorrectly tracking the gradients for the attention bias
+
+## Changed
+- (BREAKING) Upgraded to `torch` 2.1 (via `tch` 0.14.0).
 
 ## [0.21.0] - 2023-06-03
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ features = ["doc-only"]
 
 [dependencies]
 rust_tokenizers = "8.1.1"
-tch = "0.13.0"
+tch = "0.14.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "3"
@@ -97,7 +97,7 @@ anyhow = "1"
 csv = "1"
 criterion = "0.4"
 tokio = { version = "1.24", features = ["sync", "rt-multi-thread", "macros"] }
-torch-sys = "0.13.0"
+torch-sys =  "0.14.0"
 tempfile = "3"
 itertools = "0.10"
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "env-filter", "fmt" ] }

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ This cache location defaults to `~/.cache/.rustbert`, but can be changed by sett
 
 ### Manual installation (recommended)
 
-1. Download `libtorch` from https://pytorch.org/get-started/locally/. This package requires `v2.0.0`: if this version is no longer available on the "get started" page,
-the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcu118.zip` for a Linux version with CUDA11. **NOTE:** When using `rust-bert` as dependency from [crates.io](https://crates.io), please check the required `LIBTORCH` on the published package [readme](https://crates.io/crates/rust-bert) as it may differ from the version documented here (applying to the current repository version).
+1. Download `libtorch` from https://pytorch.org/get-started/locally/. This package requires `v2.1`: if this version is no longer available on the "get started" page,
+the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcu118.zip` for a Linux version with CUDA11. **NOTE:** When using `rust-bert` as dependency from [crates.io](https://crates.io), please check the required `LIBTORCH` on the published package [readme](https://crates.io/crates/rust-bert) as it may differ from the version documented here (applying to the current repository version).
 2. Extract the library to a location of your choice
 3. Set the following environment variables
 ##### Linux:

--- a/benches/generation_benchmark.rs
+++ b/benches/generation_benchmark.rs
@@ -37,6 +37,7 @@ fn create_text_generation_model() -> TextGenerationModel {
         diversity_penalty: None,
         num_return_sequences: 5,
         device: Device::cuda_if_available(),
+        kind: None,
     };
     TextGenerationModel::new(config).unwrap()
 }

--- a/examples/natural_language_inference_deberta.rs
+++ b/examples/natural_language_inference_deberta.rs
@@ -38,7 +38,7 @@ fn main() -> anyhow::Result<()> {
     )?;
     let config = DebertaConfig::from_file(config_path);
     let model = DebertaForSequenceClassification::new(vs.root(), &config)?;
-    load_weights(&model_resource, &mut vs)?;
+    load_weights(&model_resource, &mut vs, None, device)?;
 
     //    Define input
     let input = [("I love you.", "I like you.")];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,8 @@
 //!
 //! ### Manual installation (recommended)
 //!
-//! 1. Download `libtorch` from <https://pytorch.org/get-started/locally/>. This package requires `v2.0`: if this version is no longer available on the "get started" page,
-//! the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.0.0%2Bcu118.zip` for a Linux version with CUDA11.
+//! 1. Download `libtorch` from <https://pytorch.org/get-started/locally/>. This package requires `v2.1`: if this version is no longer available on the "get started" page,
+//! the file should be accessible by modifying the target link, for example `https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcu118.zip` for a Linux version with CUDA11.
 //! 2. Extract the library to a location of your choice
 //! 3. Set the following environment variables
 //! ##### Linux:

--- a/src/models/bart/bart_model.rs
+++ b/src/models/bart/bart_model.rs
@@ -1004,7 +1004,12 @@ impl BartGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = BartConfig::from_file(config_path);
         let model = BartForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(0));
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/gpt2/gpt2_model.rs
+++ b/src/models/gpt2/gpt2_model.rs
@@ -652,7 +652,12 @@ impl GPT2Generator {
 
         let config = Gpt2Config::from_file(config_path);
         let model = GPT2LMHeadModel::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = tokenizer.get_bos_id();
         let eos_token_ids = tokenizer.get_eos_id().map(|id| vec![id]);

--- a/src/models/gpt_j/gpt_j_model.rs
+++ b/src/models/gpt_j/gpt_j_model.rs
@@ -131,8 +131,6 @@ pub struct GptJConfig {
     pub rotary_dim: Option<i64>,
     pub vocab_size: i64,
     pub scale_attn_weights: Option<bool>,
-    #[serde(default = "default_use_float16")]
-    pub use_float16: bool,
     #[serde(default = "default_preload_on_cpu")]
     pub preload_on_cpu: bool,
     pub decoder_start_token_id: Option<i64>,
@@ -164,17 +162,12 @@ impl Default for GptJConfig {
             rotary_dim: Some(64),
             vocab_size: 50400,
             scale_attn_weights: Some(true),
-            use_float16: default_use_float16(),
             preload_on_cpu: default_preload_on_cpu(),
             decoder_start_token_id: None,
             forced_bos_token_id: None,
             forced_eos_token_id: None,
         }
     }
-}
-
-fn default_use_float16() -> bool {
-    true
 }
 
 fn default_preload_on_cpu() -> bool {
@@ -233,9 +226,6 @@ impl GptJModel {
             config.n_embd,
             Default::default(),
         );
-        if config.use_float16 {
-            (&(&p / "wte") / "weight").half()
-        };
 
         let embd_pdrop = config.embd_pdrop.unwrap_or(0.1);
         let drop = Dropout::new(embd_pdrop);
@@ -245,9 +235,6 @@ impl GptJModel {
             ..Default::default()
         };
         let ln_f = nn::layer_norm(&p / "ln_f", vec![config.n_embd], layer_norm_config);
-        if config.use_float16 {
-            (&p / "ln_f").half()
-        };
 
         let mut h: Vec<GptJBlock> = vec![];
         let h_path = &p / "h";
@@ -475,9 +462,6 @@ impl GptJLMHeadModel {
             config.vocab_size,
             Default::default(),
         );
-        if config.use_float16 {
-            (p / "lm_head").half();
-        }
 
         GptJLMHeadModel {
             transformer,

--- a/src/models/gpt_j/gpt_j_model.rs
+++ b/src/models/gpt_j/gpt_j_model.rs
@@ -625,7 +625,12 @@ impl GptJGenerator {
         if config.preload_on_cpu && device != Device::Cpu {
             var_store.set_device(Device::Cpu);
         }
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
         if device != Device::Cpu {
             var_store.set_device(device);
         }

--- a/src/models/gpt_j/transformer.rs
+++ b/src/models/gpt_j/transformer.rs
@@ -43,18 +43,12 @@ impl GptJMLP {
             intermediate_size,
             Default::default(),
         );
-        if config.use_float16 {
-            (p / "fc_in").half()
-        };
         let fc_out = nn::linear(
             p / "fc_out",
             intermediate_size,
             config.n_embd,
             Default::default(),
         );
-        if config.use_float16 {
-            (p / "fc_out").half()
-        };
 
         let activation = match &config.afn {
             Some(activation_enum) => match activation_enum {
@@ -100,9 +94,6 @@ impl GptJBlock {
             ..Default::default()
         };
         let ln_1 = nn::layer_norm(p / "ln_1", vec![config.n_embd], layer_norm_config);
-        if config.use_float16 {
-            (p / "ln_1").half()
-        };
         let attn = GptJAttention::new(p / "attn", config);
         let mlp = GptJMLP::new(p / "mlp", config);
 

--- a/src/models/gpt_neo/gpt_neo_model.rs
+++ b/src/models/gpt_neo/gpt_neo_model.rs
@@ -672,7 +672,12 @@ impl GptNeoGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = GptNeoConfig::from_file(config_path);
         let model = GptNeoForCausalLM::new(var_store.root(), &config)?;
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = tokenizer.get_bos_id();
         let eos_token_ids = tokenizer.get_eos_id().map(|id| vec![id]);

--- a/src/models/longt5/encoder.rs
+++ b/src/models/longt5/encoder.rs
@@ -288,8 +288,8 @@ impl LongT5Stack {
 
         let (batch_size, sequence_length) = (input_shape[0], input_shape[1]);
 
-        let mask_seq_length = if old_layer_states.is_some() {
-            if old_layer_states.as_ref().unwrap()[0].0.is_some() {
+        let mask_seq_length = if let Some(old_layer_states_value) = &old_layer_states {
+            if old_layer_states_value[0].0.is_some() {
                 old_layer_states.as_ref().unwrap()[0]
                     .0
                     .as_ref()

--- a/src/models/longt5/longt5_model.rs
+++ b/src/models/longt5/longt5_model.rs
@@ -595,7 +595,12 @@ impl LongT5Generator {
 
         let config = LongT5Config::from_file(config_path);
         let model = LongT5ForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = config.bos_token_id;
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/m2m_100/m2m_100_model.rs
+++ b/src/models/m2m_100/m2m_100_model.rs
@@ -544,7 +544,12 @@ impl M2M100Generator {
 
         let config = M2M100Config::from_file(config_path);
         let model = M2M100ForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(0));
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/marian/marian_model.rs
+++ b/src/models/marian/marian_model.rs
@@ -761,7 +761,12 @@ impl MarianGenerator {
 
         let config = BartConfig::from_file(config_path);
         let model = MarianForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(0));
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/mbart/mbart_model.rs
+++ b/src/models/mbart/mbart_model.rs
@@ -650,7 +650,7 @@ impl MBartForSequenceClassification {
     /// # let device = Device::Cpu;
     /// # let vs = nn::VarStore::new(device);
     /// # let config = MBartConfig::from_file(config_path);
-    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config).unwrap();;
+    /// # let mbart_model: MBartForSequenceClassification = MBartForSequenceClassification::new(&vs.root(), &config).unwrap();
     ///  let (batch_size, source_sequence_length, target_sequence_length) = (64, 128, 56);
     ///  let input_tensor = Tensor::rand(&[batch_size, source_sequence_length], (Int64, device));
     ///  let target_tensor = Tensor::rand(&[batch_size, target_sequence_length], (Int64, device));
@@ -800,7 +800,12 @@ impl MBartGenerator {
 
         let config = MBartConfig::from_file(config_path);
         let model = MBartForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(0));
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/openai_gpt/openai_gpt_model.rs
+++ b/src/models/openai_gpt/openai_gpt_model.rs
@@ -498,7 +498,12 @@ impl OpenAIGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = Gpt2Config::from_file(config_path);
         let model = OpenAIGPTLMHeadModel::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = tokenizer.get_bos_id();
         let eos_token_ids = tokenizer.get_eos_id().map(|id| vec![id]);

--- a/src/models/pegasus/pegasus_model.rs
+++ b/src/models/pegasus/pegasus_model.rs
@@ -505,7 +505,12 @@ impl PegasusConditionalGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = PegasusConfig::from_file(config_path);
         let model = PegasusForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(0));
         let eos_token_ids = config

--- a/src/models/prophetnet/prophetnet_model.rs
+++ b/src/models/prophetnet/prophetnet_model.rs
@@ -919,7 +919,12 @@ impl ProphetNetConditionalGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = ProphetNetConfig::from_file(config_path);
         let model = ProphetNetForConditionalGeneration::new(var_store.root(), &config)?;
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id);
         let eos_token_ids = Some(vec![config.eos_token_id]);

--- a/src/models/reformer/attention.rs
+++ b/src/models/reformer/attention.rs
@@ -1368,8 +1368,8 @@ impl ReformerAttention {
         let new_layer_state = if self.use_past {
             let prev_buckets = if let Some(buckets_value) = &buckets {
                 if layer_state.is_none() | {
-                    if layer_state.is_some() {
-                        layer_state.as_ref().unwrap().prev_buckets.is_none()
+                    if let Some(layer_state_value) = &layer_state {
+                        layer_state_value.prev_buckets.is_none()
                     } else {
                         false
                     }

--- a/src/models/reformer/reformer_model.rs
+++ b/src/models/reformer/reformer_model.rs
@@ -1056,7 +1056,12 @@ impl ReformerGenerator {
         let mut var_store = nn::VarStore::new(device);
         let config = ReformerConfig::from_file(config_path);
         let model = ReformerModelWithLMHead::new(var_store.root(), &config)?;
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = tokenizer.get_bos_id();
         let eos_token_ids = tokenizer.get_eos_id().map(|id| vec![id]);

--- a/src/models/t5/attention.rs
+++ b/src/models/t5/attention.rs
@@ -191,15 +191,15 @@ impl T5Attention {
 
         let q: Tensor = self.shape(hidden_states.as_ref().apply(&self.query), bs);
 
-        let (mut k, mut v) = if key_value_states.is_none() {
+        let (mut k, mut v) = if let Some(key_value_states_value) = key_value_states {
             (
-                self.shape(hidden_states.apply(&self.key), bs),
-                self.shape(hidden_states.apply(&self.value), bs),
+                self.shape(key_value_states_value.apply(&self.key), bs),
+                self.shape(key_value_states_value.apply(&self.value), bs),
             )
         } else {
             (
-                self.shape(key_value_states.as_ref().unwrap().apply(&self.key), bs),
-                self.shape(key_value_states.as_ref().unwrap().apply(&self.value), bs),
+                self.shape(hidden_states.apply(&self.key), bs),
+                self.shape(hidden_states.apply(&self.value), bs),
             )
         };
 

--- a/src/models/t5/encoder.rs
+++ b/src/models/t5/encoder.rs
@@ -383,9 +383,9 @@ impl T5Stack {
 
         let (batch_size, sequence_length) = (input_shape[0], input_shape[1]);
 
-        let mask_seq_length = if old_layer_states.is_some() {
-            if old_layer_states.as_ref().unwrap()[0].0.is_some() {
-                old_layer_states.as_ref().unwrap()[0]
+        let mask_seq_length = if let Some(old_layer_states_value) = &old_layer_states {
+            if old_layer_states_value[0].0.is_some() {
+                old_layer_states_value[0]
                     .0
                     .as_ref()
                     .unwrap()

--- a/src/models/t5/t5_model.rs
+++ b/src/models/t5/t5_model.rs
@@ -763,7 +763,12 @@ impl T5Generator {
 
         let config = T5Config::from_file(config_path);
         let model = T5ForConditionalGeneration::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id.unwrap_or(-1));
         let eos_token_ids = Some(match config.eos_token_id {

--- a/src/models/xlnet/xlnet_model.rs
+++ b/src/models/xlnet/xlnet_model.rs
@@ -1560,7 +1560,12 @@ impl XLNetGenerator {
 
         let config = XLNetConfig::from_file(config_path);
         let model = XLNetLMHeadModel::new(var_store.root(), &config);
-        crate::resources::load_weights(&generate_config.model_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &generate_config.model_resource,
+            &mut var_store,
+            generate_config.kind,
+            device,
+        )?;
 
         let bos_token_id = Some(config.bos_token_id);
         let eos_token_ids = Some(vec![config.eos_token_id]);

--- a/src/pipelines/common.rs
+++ b/src/pipelines/common.rs
@@ -60,6 +60,7 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use std::path::{Path, PathBuf};
+use tch::nn::VarStore;
 use tch::{Device, Kind, Tensor};
 
 #[cfg(feature = "onnx")]
@@ -2346,5 +2347,13 @@ impl TokenizerOption {
             #[cfg(feature = "hf-tokenizers")]
             Self::HFTokenizer(ref mut tokenizer) => tokenizer.add_tokens(tokens),
         }
+    }
+}
+
+pub fn cast_var_store(varstore: &mut VarStore, kind: Option<Kind>, device: Device) {
+    match (kind, device) {
+        (Some(kind), _) => varstore.set_kind(kind),
+        (None, Device::Cpu) => varstore.set_kind(Kind::Float),
+        (None, _) => {}
     }
 }

--- a/src/pipelines/conversation.rs
+++ b/src/pipelines/conversation.rs
@@ -115,6 +115,8 @@ pub struct ConversationConfig {
     pub diversity_penalty: Option<f64>,
     /// Device to place the model on (default: CUDA/GPU when available)
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 #[cfg(feature = "remote")]
@@ -150,6 +152,7 @@ impl Default for ConversationConfig {
             num_beam_groups: None,
             diversity_penalty: None,
             device: Device::cuda_if_available(),
+            kind: None,
         }
     }
 }
@@ -177,6 +180,7 @@ impl From<ConversationConfig> for GenerateConfig {
             num_beam_groups: config.num_beam_groups,
             diversity_penalty: config.diversity_penalty,
             device: config.device,
+            kind: config.kind,
         }
     }
 }

--- a/src/pipelines/generation_utils.rs
+++ b/src/pipelines/generation_utils.rs
@@ -67,7 +67,7 @@
 //! ```
 
 use tch::kind::Kind::Int64;
-use tch::{no_grad, Device, Tensor};
+use tch::{no_grad, Device, Kind, Tensor};
 
 use crate::bart::LayerState as BartLayerState;
 use crate::common::resources::ResourceProvider;
@@ -136,6 +136,8 @@ pub struct GenerateConfig {
     pub diversity_penalty: Option<f64>,
     /// Device to place the model on (default: CUDA/GPU when available)
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 #[cfg(feature = "remote")]
@@ -166,6 +168,7 @@ impl Default for GenerateConfig {
             num_beam_groups: None,
             diversity_penalty: None,
             device: Device::cuda_if_available(),
+            kind: None,
         }
     }
 }

--- a/src/pipelines/pos_tagging.rs
+++ b/src/pipelines/pos_tagging.rs
@@ -138,6 +138,7 @@ impl Default for POSConfig {
                 strip_accents: Some(true),
                 add_prefix_space: None,
                 device: Device::cuda_if_available(),
+                kind: None,
                 label_aggregation_function: LabelAggregationOption::First,
                 batch_size: 64,
             },

--- a/src/pipelines/sentence_embeddings/builder.rs
+++ b/src/pipelines/sentence_embeddings/builder.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use serde::Deserialize;
-use tch::Device;
+use tch::{Device, Kind};
 
 use crate::pipelines::common::ModelType;
 use crate::pipelines::sentence_embeddings::{
@@ -21,12 +21,18 @@ use crate::{
 /// (configuration and weights).
 pub struct SentenceEmbeddingsBuilder<T> {
     device: Device,
+    kind: Option<Kind>,
     inner: T,
 }
 
 impl<T> SentenceEmbeddingsBuilder<T> {
     pub fn with_device(mut self, device: Device) -> Self {
         self.device = device;
+        self
+    }
+
+    pub fn with_kind(mut self, kind: Kind) -> Self {
+        self.kind = Some(kind);
         self
     }
 }
@@ -46,6 +52,7 @@ impl SentenceEmbeddingsBuilder<Local> {
     pub fn local<P: Into<PathBuf>>(model_dir: P) -> Self {
         Self {
             device: Device::cuda_if_available(),
+            kind: None,
             inner: Local {
                 model_dir: model_dir.into(),
             },
@@ -106,6 +113,7 @@ impl SentenceEmbeddingsBuilder<Local> {
             tokenizer_vocab_resource: tokenizer_vocab.into(),
             tokenizer_merges_resource: tokenizer_merges.map(|r| r.into()),
             device: self.device,
+            kind: self.kind,
         };
 
         SentenceEmbeddingsModel::new(config)
@@ -122,6 +130,7 @@ impl SentenceEmbeddingsBuilder<Remote> {
     pub fn remote(model_type: SentenceEmbeddingsModelType) -> Self {
         Self {
             device: Device::cuda_if_available(),
+            kind: None,
             inner: Remote {
                 config: SentenceEmbeddingsConfig::from(model_type),
             },

--- a/src/pipelines/sentence_embeddings/config.rs
+++ b/src/pipelines/sentence_embeddings/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tch::Device;
+use tch::{Device, Kind};
 
 use crate::pipelines::common::ModelType;
 use crate::resources::ResourceProvider;
@@ -55,6 +55,8 @@ pub struct SentenceEmbeddingsConfig {
     pub tokenizer_merges_resource: Option<Box<dyn ResourceProvider + Send>>,
     /// Device to place the transformer model on
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 #[cfg(feature = "remote")]
@@ -92,6 +94,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                 )),
                 tokenizer_merges_resource: None,
                 device: Device::cuda_if_available(),
+                kind: None,
             },
 
             SentenceEmbeddingsModelType::BertBaseNliMeanTokens => SentenceEmbeddingsConfig {
@@ -121,6 +124,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                 )),
                 tokenizer_merges_resource: None,
                 device: Device::cuda_if_available(),
+                kind: None,
             },
 
             SentenceEmbeddingsModelType::AllMiniLmL12V2 => SentenceEmbeddingsConfig {
@@ -149,7 +153,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                     BertVocabResources::ALL_MINI_LM_L12_V2,
                 )),
                 tokenizer_merges_resource: None,
-                device: Device::cuda_if_available(),
+                device: Device::cuda_if_available(),                kind: None,
             },
 
             SentenceEmbeddingsModelType::AllMiniLmL6V2 => SentenceEmbeddingsConfig {
@@ -178,7 +182,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                     BertVocabResources::ALL_MINI_LM_L6_V2,
                 )),
                 tokenizer_merges_resource: None,
-                device: Device::cuda_if_available(),
+                device: Device::cuda_if_available(),                kind: None,
             },
 
             SentenceEmbeddingsModelType::AllDistilrobertaV1 => SentenceEmbeddingsConfig {
@@ -209,7 +213,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                 tokenizer_merges_resource: Some(Box::new(RemoteResource::from_pretrained(
                     RobertaMergesResources::ALL_DISTILROBERTA_V1,
                 ))),
-                device: Device::cuda_if_available(),
+                device: Device::cuda_if_available(),                kind: None,
             },
 
             SentenceEmbeddingsModelType::ParaphraseAlbertSmallV2 => SentenceEmbeddingsConfig {
@@ -238,7 +242,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                     AlbertVocabResources::PARAPHRASE_ALBERT_SMALL_V2,
                 )),
                 tokenizer_merges_resource: None,
-                device: Device::cuda_if_available(),
+                device: Device::cuda_if_available(),                kind: None,
             },
 
             SentenceEmbeddingsModelType::SentenceT5Base => SentenceEmbeddingsConfig {
@@ -271,7 +275,7 @@ impl From<SentenceEmbeddingsModelType> for SentenceEmbeddingsConfig {
                     T5VocabResources::SENTENCE_T5_BASE,
                 )),
                 tokenizer_merges_resource: None,
-                device: Device::cuda_if_available(),
+                device: Device::cuda_if_available(),                kind: None,
             },
         }
     }

--- a/src/pipelines/sentence_embeddings/pipeline.rs
+++ b/src/pipelines/sentence_embeddings/pipeline.rs
@@ -236,6 +236,7 @@ impl SentenceEmbeddingsModel {
             dense_config_resource,
             dense_weights_resource,
             device,
+            kind,
         } = config;
 
         let modules =
@@ -254,7 +255,12 @@ impl SentenceEmbeddingsModel {
         );
         let transformer =
             SentenceEmbeddingsOption::new(transformer_type, var_store.root(), &transformer_config)?;
-        crate::resources::load_weights(&transformer_weights_resource, &mut var_store)?;
+        crate::resources::load_weights(
+            &transformer_weights_resource,
+            &mut var_store,
+            kind,
+            device,
+        )?;
 
         // Setup pooling layer
         let pooling_config = PoolingConfig::from_file(pooling_config_resource.get_local_path()?);

--- a/src/pipelines/sequence_classification.rs
+++ b/src/pipelines/sequence_classification.rs
@@ -68,7 +68,7 @@ use crate::fnet::FNetForSequenceClassification;
 use crate::longformer::LongformerForSequenceClassification;
 use crate::mobilebert::MobileBertForSequenceClassification;
 use crate::pipelines::common::{
-    get_device, ConfigOption, ModelResource, ModelType, TokenizerOption,
+    cast_var_store, get_device, ConfigOption, ModelResource, ModelType, TokenizerOption,
 };
 use crate::reformer::ReformerForSequenceClassification;
 use crate::resources::ResourceProvider;
@@ -123,6 +123,8 @@ pub struct SequenceClassificationConfig {
     pub add_prefix_space: Option<bool>,
     /// Device to place the model on (default: CUDA/GPU when available)
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 impl SequenceClassificationConfig {
@@ -160,6 +162,7 @@ impl SequenceClassificationConfig {
             strip_accents: strip_accents.into(),
             add_prefix_space: add_prefix_space.into(),
             device: Device::cuda_if_available(),
+            kind: None,
         }
     }
 }
@@ -392,6 +395,7 @@ impl SequenceClassificationOption {
             ))),
         }?;
         var_store.load(weights_path)?;
+        cast_var_store(&mut var_store, config.kind, device);
         Ok(model)
     }
 

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -62,7 +62,7 @@
 //! # ;
 //! ```
 
-use tch::Device;
+use tch::{Device, Kind};
 
 use crate::bart::BartGenerator;
 use crate::common::error::RustBertError;
@@ -126,6 +126,8 @@ pub struct SummarizationConfig {
     pub diversity_penalty: Option<f64>,
     /// Device to place the model on (default: CUDA/GPU when available)
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 impl SummarizationConfig {
@@ -170,6 +172,7 @@ impl SummarizationConfig {
             num_beam_groups: None,
             diversity_penalty: None,
             device: Device::cuda_if_available(),
+            kind: None,
         }
     }
 }
@@ -214,6 +217,7 @@ impl From<SummarizationConfig> for GenerateConfig {
             num_beam_groups: config.num_beam_groups,
             diversity_penalty: config.diversity_penalty,
             device: config.device,
+            kind: config.kind,
         }
     }
 }

--- a/src/pipelines/text_generation.rs
+++ b/src/pipelines/text_generation.rs
@@ -31,7 +31,7 @@
 //!
 //! Customized text generation models models can be loaded by overwriting the resources in the configuration.
 //! The dependencies will be downloaded to the user's home directory, e.g. under ~/.cache/.rustbert/gpt2
-use tch::Device;
+use tch::{Device, Kind};
 
 use crate::common::error::RustBertError;
 use crate::gpt2::GPT2Generator;
@@ -97,6 +97,8 @@ pub struct TextGenerationConfig {
     pub diversity_penalty: Option<f64>,
     /// Device to place the model on (default: CUDA/GPU when available)
     pub device: Device,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 impl TextGenerationConfig {
@@ -141,6 +143,7 @@ impl TextGenerationConfig {
             num_beam_groups: None,
             diversity_penalty: None,
             device: Device::cuda_if_available(),
+            kind: None,
         }
     }
 }
@@ -185,6 +188,7 @@ impl From<TextGenerationConfig> for GenerateConfig {
             num_beam_groups: config.num_beam_groups,
             diversity_penalty: config.diversity_penalty,
             device: config.device,
+            kind: config.kind,
         }
     }
 }

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tch::Device;
+use tch::{Device, Kind};
 
 use crate::common::error::RustBertError;
 use crate::m2m_100::M2M100Generator;
@@ -978,6 +978,8 @@ pub struct TranslationConfig {
     pub num_beam_groups: Option<i64>,
     /// Diversity penalty for diverse beam search. High values will enforce more difference between beam groups (default: 5.5)
     pub diversity_penalty: Option<f64>,
+    /// Model weights precision. If not provided, will default to full precision on CPU, or the loaded weights precision otherwise
+    pub kind: Option<Kind>,
 }
 
 impl TranslationConfig {
@@ -1065,6 +1067,7 @@ impl TranslationConfig {
             num_return_sequences: 1,
             num_beam_groups: None,
             diversity_penalty: None,
+            kind: None,
         }
     }
 }
@@ -1092,6 +1095,7 @@ impl From<TranslationConfig> for GenerateConfig {
             num_beam_groups: config.num_beam_groups,
             diversity_penalty: config.diversity_penalty,
             device: config.device,
+            kind: config.kind,
         }
     }
 }

--- a/tests/albert.rs
+++ b/tests/albert.rs
@@ -35,7 +35,7 @@ fn albert_masked_lm() -> anyhow::Result<()> {
         AlbertTokenizer::from_file(vocab_path.to_str().unwrap(), true, false)?;
     let config = AlbertConfig::from_file(config_path);
     let albert_model = AlbertForMaskedLM::new(vs.root(), &config);
-    load_weights(&weights_resource, &mut vs)?;
+    load_weights(&weights_resource, &mut vs, None, device)?;
 
     //    Define input
     let input = [

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -2,7 +2,7 @@ use rust_bert::bart::{
     BartConfig, BartConfigResources, BartMergesResources, BartModel, BartModelResources,
     BartVocabResources,
 };
-use rust_bert::pipelines::common::ModelResource;
+use rust_bert::pipelines::common::{cast_var_store, ModelResource};
 use rust_bert::pipelines::summarization::{SummarizationConfig, SummarizationModel};
 use rust_bert::pipelines::zero_shot_classification::{
     ZeroShotClassificationConfig, ZeroShotClassificationModel,
@@ -44,6 +44,7 @@ fn bart_lm_model() -> anyhow::Result<()> {
     let config = BartConfig::from_file(config_path);
     let bart_model = BartModel::new(&vs.root() / "model", &config);
     vs.load(weights_path)?;
+    cast_var_store(&mut vs, None, device);
 
     //    Define input
     let input = ["One two three four"];

--- a/tests/onnx.rs
+++ b/tests/onnx.rs
@@ -234,15 +234,15 @@ mod tests {
             ModelType::M2M100,
             ModelResource::ONNX(ONNXModelResources {
                 encoder_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/encoder_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/resolve/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/encoder_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
                 decoder_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/resolve/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
                 decoder_with_past_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_with_past_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/resolve/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_with_past_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
             }),

--- a/tests/onnx.rs
+++ b/tests/onnx.rs
@@ -234,15 +234,15 @@ mod tests {
             ModelType::M2M100,
             ModelResource::ONNX(ONNXModelResources {
                 encoder_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/resolve/main/encoder_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/encoder_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
                 decoder_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/resolve/main/decoder_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
                 decoder_with_past_resource: Some(Box::new(RemoteResource::new(
-                    "https://huggingface.co/optimum/m2m100_418M/resolve/main/decoder_with_past_model.onnx",
+                    "https://huggingface.co/optimum/m2m100_418M/blob/e775f50e63b178d82b8d736fc43fcf5ef15d2f6c/decoder_with_past_model.onnx",
                     "onnx-m2m100_418M",
                 ))),
             }),


### PR DESCRIPTION
- Added optional `kind` parameter to specify the model weight precision to most pipeline configurations. If not provided, will default to full precision on CPU, or the serialized weights precision otherwise.
- Fixed issue with GPT-J that was incorrectly tracking the gradients for the attention bias
- Upgraded to `torch` 2.1 (via `tch` 0.14.0).

Fixes https://github.com/guillaume-be/rust-bert/issues/434