### PR TITLE
Change `generate` return type to Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Changed
 - (BREAKING) Upgraded to `torch` 2.1 (via `tch` 0.14.0).
+- (BREAKING) Text generation traits and pipelines (including conversation, summarization and translation) now return a `Result` for improved error handling
 
 ## [0.21.0] - 2023-06-03
 ## Added

--- a/examples/buffer_resource.rs
+++ b/examples/buffer_resource.rs
@@ -49,7 +49,7 @@ about exoplanets like K2-18b."];
     let summarization_model = SummarizationModel::new(config(Device::Cpu, weights.clone()))?;
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = summarization_model.summarize(&input);
+    let output = summarization_model.summarize(&input)?;
     for sentence in output {
         println!("{sentence}");
     }
@@ -58,7 +58,7 @@ about exoplanets like K2-18b."];
         SummarizationModel::new(config(Device::cuda_if_available(), weights))?;
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = summarization_model.summarize(&input);
+    let output = summarization_model.summarize(&input)?;
     for sentence in output {
         println!("{sentence}");
     }

--- a/examples/generation_gpt2.rs
+++ b/examples/generation_gpt2.rs
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
 
     let input_context = "The dog";
     // let second_input_context = "The cat was";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     for sentence in output {
         println!("{sentence:?}");

--- a/examples/generation_gpt2_hf_tokenizers.rs
+++ b/examples/generation_gpt2_hf_tokenizers.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
 
     let input_context = "The dog";
     // let second_input_context = "The cat was";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     for sentence in output {
         println!("{sentence:?}");

--- a/examples/generation_gpt_neo.rs
+++ b/examples/generation_gpt_neo.rs
@@ -57,7 +57,7 @@ fn main() -> anyhow::Result<()> {
 
     let input_context_1 = "It was a very nice and sunny";
     let input_context_2 = "It was a gloom winter night, and";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     for sentence in output {
         println!("{sentence}");

--- a/examples/generation_gptj.rs
+++ b/examples/generation_gptj.rs
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
         "It was a very nice and sunny",
         "It was a gloom winter night, and",
     ];
-    let output = model.generate(&prompts, None);
+    let output = model.generate(&prompts, None)?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(output[0], "It was a very nice and sunny day, and I was sitting in the garden of my house, enjoying the sun and the fresh air. I was thinking");

--- a/examples/generation_reformer.rs
+++ b/examples/generation_reformer.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
 
     let input_context_1 = "The really great men must, I think,";
     let input_context_2 = "It was a gloom winter night, and";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     for sentence in output {
         println!("{sentence}");

--- a/examples/generation_xlnet.rs
+++ b/examples/generation_xlnet.rs
@@ -47,7 +47,7 @@ fn main() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "Once upon a time,";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     for sentence in output {
         println!("{sentence}");

--- a/examples/summarization_bart.rs
+++ b/examples/summarization_bart.rs
@@ -72,7 +72,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let _output = summarization_model.summarize(&input);
+    let _output = summarization_model.summarize(&input)?;
     for sentence in _output {
         println!("{sentence}");
     }

--- a/examples/summarization_pegasus.rs
+++ b/examples/summarization_pegasus.rs
@@ -66,7 +66,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let _output = summarization_model.summarize(&input);
+    let _output = summarization_model.summarize(&input)?;
     for sentence in _output {
         println!("{sentence}");
     }

--- a/examples/summarization_prophetnet.rs
+++ b/examples/summarization_prophetnet.rs
@@ -68,7 +68,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let _output = summarization_model.summarize(&input);
+    let _output = summarization_model.summarize(&input)?;
     for sentence in _output {
         println!("{sentence}");
     }

--- a/examples/summarization_t5.rs
+++ b/examples/summarization_t5.rs
@@ -54,7 +54,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let _output = summarization_model.summarize(&input);
+    let _output = summarization_model.summarize(&input)?;
     for sentence in _output {
         println!("{sentence}");
     }

--- a/src/models/gpt_neo/mod.rs
+++ b/src/models/gpt_neo/mod.rs
@@ -55,7 +55,7 @@
 //!
 //!     let input_context_1 = "It was a very nice and sunny";
 //!     let input_context_2 = "It was a gloom winter night, and";
-//!     let output = model.generate(&[input_context_1, input_context_2], None);
+//!     let output = model.generate(&[input_context_1, input_context_2], None)?;
 //!
 //!     for sentence in output {
 //!         println!("{}", sentence);

--- a/src/models/prophetnet/mod.rs
+++ b/src/models/prophetnet/mod.rs
@@ -72,7 +72,7 @@
 //! about exoplanets like K2-18b."];
 //!
 //!     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-//!     let _output = summarization_model.summarize(&input);
+//!     let _output = summarization_model.summarize(&input)?;
 //!     for sentence in _output {
 //!         println!("{}", sentence);
 //!     }

--- a/src/pipelines/summarization.rs
+++ b/src/pipelines/summarization.rs
@@ -338,43 +338,43 @@ impl SummarizationOption {
     }
 
     /// Interface method to generate() of the particular models.
-    pub fn generate<S>(&self, prompt_texts: Option<&[S]>) -> Vec<String>
+    pub fn generate<S>(&self, prompt_texts: Option<&[S]>) -> Result<Vec<String>, RustBertError>
     where
         S: AsRef<str> + Send + Sync,
     {
-        match *self {
+        Ok(match *self {
             Self::Bart(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::LongT5(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::ProphetNet(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::Pegasus(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             #[cfg(feature = "onnx")]
             Self::ONNX(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
-        }
+        })
     }
 }
 
@@ -506,7 +506,7 @@ impl SummarizationModel {
     /// # }
     /// ```
     /// (New sample credits: [WikiNews](https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b))
-    pub fn summarize<S>(&self, texts: &[S]) -> Vec<String>
+    pub fn summarize<S>(&self, texts: &[S]) -> Result<Vec<String>, RustBertError>
     where
         S: AsRef<str> + Send + Sync,
     {

--- a/src/pipelines/translation/translation_pipeline.rs
+++ b/src/pipelines/translation/translation_pipeline.rs
@@ -1219,18 +1219,18 @@ impl TranslationOption {
         &self,
         prompt_texts: Option<&[S]>,
         forced_bos_token_id: Option<i64>,
-    ) -> Vec<String>
+    ) -> Result<Vec<String>, RustBertError>
     where
         S: AsRef<str> + Send + Sync,
     {
-        match *self {
+        Ok(match *self {
             Self::Marian(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
             Self::T5(ref model) => model
-                .generate(prompt_texts, None)
+                .generate(prompt_texts, None)?
                 .into_iter()
                 .map(|output| output.text)
                 .collect(),
@@ -1240,7 +1240,7 @@ impl TranslationOption {
                     ..Default::default()
                 };
                 model
-                    .generate(prompt_texts, Some(generate_options))
+                    .generate(prompt_texts, Some(generate_options))?
                     .into_iter()
                     .map(|output| output.text)
                     .collect()
@@ -1251,7 +1251,7 @@ impl TranslationOption {
                     ..Default::default()
                 };
                 model
-                    .generate(prompt_texts, Some(generate_options))
+                    .generate(prompt_texts, Some(generate_options))?
                     .into_iter()
                     .map(|output| output.text)
                     .collect()
@@ -1264,12 +1264,12 @@ impl TranslationOption {
                         ..Default::default()
                     });
                 model
-                    .generate(prompt_texts, generate_options)
+                    .generate(prompt_texts, generate_options)?
                     .into_iter()
                     .map(|output| output.text)
                     .collect()
             }
-        }
+        })
     }
 }
 
@@ -1484,7 +1484,7 @@ impl TranslationModel {
                 &self.supported_target_languages,
             )?;
 
-        Ok(match prefix {
+        match prefix {
             Some(value) => {
                 let texts = texts
                     .iter()
@@ -1493,7 +1493,7 @@ impl TranslationModel {
                 self.model.generate(Some(&texts), forced_bos_token_id)
             }
             None => self.model.generate(Some(texts), forced_bos_token_id),
-        })
+        }
     }
 }
 

--- a/tests/bart.rs
+++ b/tests/bart.rs
@@ -128,7 +128,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = model.summarize(&input);
+    let output = model.summarize(&input)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(output[0], " K2-18b is not too hot and not too cold for liquid water to exist. \
@@ -189,7 +189,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = model.summarize(&input);
+    let output = model.summarize(&input)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(output[0], " K2-18b, a planet circling a star in the constellation Leo, is not too hot and not too cold for liquid water to exist. \

--- a/tests/gpt2.rs
+++ b/tests/gpt2.rs
@@ -121,7 +121,7 @@ fn gpt2_generation_greedy() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "The cat";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(output[0], "The cat was found in a field near the town of Keflavik, about 30 miles (48 kilometers) south-east of Moscow.\n\n\n");
@@ -154,7 +154,7 @@ fn gpt2_generation_beam_search() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "The dog";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     assert_eq!(output.len(), 3);
     assert_eq!(
@@ -199,7 +199,7 @@ fn gpt2_generation_beam_search_multiple_prompts_without_padding() -> anyhow::Res
 
     let input_context_1 = "The dog";
     let input_context_2 = "The cat";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 6);
     assert_eq!(
@@ -255,7 +255,7 @@ fn gpt2_generation_beam_search_multiple_prompts_with_padding() -> anyhow::Result
 
     let input_context_1 = "The dog";
     let input_context_2 = "The cat was";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 6);
     assert_eq!(
@@ -313,7 +313,7 @@ fn gpt2_diverse_beam_search_multiple_prompts_with_padding() -> anyhow::Result<()
 
     let input_context_1 = "It was a nice and";
     let input_context_2 = "Language models can generate";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 6);
     assert_eq!(
@@ -392,7 +392,7 @@ fn gpt2_prefix_allowed_token_greedy() -> anyhow::Result<()> {
     let output = model.generate(
         Some(&[input_context_1, input_context_2]),
         Some(generate_options),
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(
@@ -455,8 +455,9 @@ fn gpt2_bad_tokens_greedy() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    let baseline_output = model.generate(Some(&[input_context_1]), Some(baseline_generate_options));
-    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options));
+    let baseline_output =
+        model.generate(Some(&[input_context_1]), Some(baseline_generate_options))?;
+    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options))?;
 
     assert_eq!(baseline_output.len(), 1);
     assert_eq!(
@@ -521,8 +522,9 @@ fn gpt2_bad_tokens_beam_search() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    let baseline_output = model.generate(Some(&[input_context_1]), Some(baseline_generate_options));
-    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options));
+    let baseline_output =
+        model.generate(Some(&[input_context_1]), Some(baseline_generate_options))?;
+    let output = model.generate(Some(&[input_context_1]), Some(test_generate_options))?;
 
     assert_eq!(baseline_output.len(), 1);
     assert_eq!(
@@ -589,7 +591,7 @@ fn gpt2_prefix_allowed_token_beam_search() -> anyhow::Result<()> {
     let output = model.generate(
         Some(&[input_context_1, input_context_2]),
         Some(generate_options),
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(
@@ -638,7 +640,7 @@ fn gpt2_greedy_token_scores() -> anyhow::Result<()> {
     let output = model.generate_indices(
         Some(&[input_context_1, input_context_2]),
         Some(generate_options),
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(
@@ -694,7 +696,7 @@ fn gpt2_beam_search_token_scores() -> anyhow::Result<()> {
     let output = model.generate_indices(
         Some(&[input_context_1, input_context_2]),
         Some(generate_options),
-    );
+    )?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(
@@ -735,7 +737,7 @@ fn dialogpt_single_multi_turn_conversation() -> anyhow::Result<()> {
         conversation_manager.create("Going to the movies tonight - any suggestions?");
 
     // Turn 1
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 1);
     assert_eq!(output.get(&conversation_id).unwrap(), &"The Big Lebowski");
 
@@ -744,12 +746,12 @@ fn dialogpt_single_multi_turn_conversation() -> anyhow::Result<()> {
         .get(&conversation_id)
         .unwrap()
         .add_user_input("Is it an action movie?");
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 1);
     assert_eq!(output.get(&conversation_id).unwrap(), &"It\'s a comedy.");
 
     // Turn 3 (no new user input)
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 0);
 
     Ok(())
@@ -773,7 +775,7 @@ fn dialogpt_multiple_multi_turn_conversation() -> anyhow::Result<()> {
     let conversation_2_id = conversation_manager.create("What's the last book you have read?");
 
     // Turn 1
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 2);
     assert_eq!(output.get(&conversation_1_id).unwrap(), &"The Big Lebowski");
     assert_eq!(
@@ -786,12 +788,12 @@ fn dialogpt_multiple_multi_turn_conversation() -> anyhow::Result<()> {
         .get(&conversation_1_id)
         .unwrap()
         .add_user_input("Is it an action movie?");
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 1);
     assert_eq!(output.get(&conversation_1_id).unwrap(), &"It\'s a comedy.");
 
     // Turn 3 (no new user input)
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 0);
 
     Ok(())
@@ -817,7 +819,7 @@ fn dialogpt_multiple_multi_turn_conversation_with_truncation() -> anyhow::Result
     let conversation_2_id = conversation_manager.create("Hello how are you?");
 
     // Turn 1
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 2);
     assert_eq!(output.get(&conversation_1_id).unwrap(), &"The Big Lebowski");
     assert_eq!(
@@ -835,12 +837,12 @@ fn dialogpt_multiple_multi_turn_conversation_with_truncation() -> anyhow::Result
         .unwrap()
         .add_user_input("Fine.");
 
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 2);
     assert_eq!(output.get(&conversation_1_id).unwrap(), &"It\'s a comedy.");
 
     // Turn 3 (no new user input)
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 0);
 
     Ok(())
@@ -864,7 +866,7 @@ fn dialogpt_multiple_multi_turn_conversation_with_conversation_deletion() -> any
     let conversation_2_id = conversation_manager.create("What's the last book you have read?");
 
     // Turn 1
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 2);
     assert_eq!(output.get(&conversation_1_id).unwrap(), &"The Big Lebowski");
     assert_eq!(
@@ -878,7 +880,7 @@ fn dialogpt_multiple_multi_turn_conversation_with_conversation_deletion() -> any
         .get(&conversation_2_id)
         .unwrap()
         .add_user_input("Why do you recommend it?");
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 1);
     assert_eq!(
         output.get(&conversation_2_id).unwrap(),
@@ -886,7 +888,7 @@ fn dialogpt_multiple_multi_turn_conversation_with_conversation_deletion() -> any
     );
 
     // Turn 3 (no new user input)
-    let output = conversation_model.generate_responses(&mut conversation_manager);
+    let output = conversation_model.generate_responses(&mut conversation_manager)?;
     assert_eq!(output.len(), 0);
 
     Ok(())

--- a/tests/gpt_neo.rs
+++ b/tests/gpt_neo.rs
@@ -143,7 +143,7 @@ fn test_generation_gpt_neo() -> anyhow::Result<()> {
 
     let input_context_1 = "It was a very nice and sunny";
     let input_context_2 = "It was a gloom winter night, and";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(output[0], "It was a very nice and sunny day. The sun was shining through the clouds, and the sky was clear. The wind was blowing through the trees,");

--- a/tests/hf_tokenizers.rs
+++ b/tests/hf_tokenizers.rs
@@ -53,7 +53,7 @@ mod tests {
         let model = TextGenerationModel::new_with_tokenizer(generate_config, tokenizer)?;
 
         let input_context = "The dog";
-        let output = model.generate(&[input_context], None);
+        let output = model.generate(&[input_context], None)?;
 
         assert_eq!(output.len(), 3);
         assert_eq!(

--- a/tests/longt5.rs
+++ b/tests/longt5.rs
@@ -49,7 +49,7 @@ on K2-18b lasts 33 Earth days. According to The Guardian, astronomers were optim
 telescope — scheduled for launch in 2021 — and the European Space Agency's 2028 ARIEL program, could reveal more \
 about exoplanets like K2-18b."];
 
-    let output = model.summarize(&input);
+    let output = model.summarize(&input)?;
 
     assert_eq! (
         output[0],

--- a/tests/onnx.rs
+++ b/tests/onnx.rs
@@ -222,7 +222,7 @@ mod tests {
             ..Default::default()
         })?;
         let prompts = ["It was a very nice and sunny"];
-        let output = text_generation_model.generate(&prompts, None);
+        let output = text_generation_model.generate(&prompts, None)?;
         assert_eq!(output.len(), 1);
         assert_eq!(output[0], "It was a very nice and sunny day. I was very happy with the weather. I was very happy with the weather. I was very happy with");
         Ok(())

--- a/tests/openai_gpt.rs
+++ b/tests/openai_gpt.rs
@@ -134,7 +134,7 @@ fn openai_gpt_generation_greedy() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "It was an intense machine dialogue. ";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(output[0], "it was an intense machine dialogue. \n \" i\'m sorry, but we have to go now! the police are on their way and they\'re going after you - or at least that\'s what my");
@@ -176,7 +176,7 @@ fn openai_gpt_generation_beam_search() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "The dog is";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     assert_eq!(output.len(), 3);
     assert_eq!(
@@ -230,7 +230,7 @@ fn openai_gpt_generation_beam_search_multiple_prompts_without_padding() -> anyho
 
     let input_context_1 = "The dog is";
     let input_context_2 = "The cat";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 6);
 
@@ -298,7 +298,7 @@ fn openai_gpt_generation_beam_search_multiple_prompts_with_padding() -> anyhow::
 
     let input_context_1 = "The dog is";
     let input_context_2 = "The cat was in";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 6);
     //    Left padding impacts the generated sentences output

--- a/tests/pegasus.rs
+++ b/tests/pegasus.rs
@@ -54,7 +54,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = summarization_model.summarize(&input);
+    let output = summarization_model.summarize(&input)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(

--- a/tests/prophetnet.rs
+++ b/tests/prophetnet.rs
@@ -57,7 +57,7 @@ telescope — scheduled for launch in 2021 — and the European Space Agency's 2
 about exoplanets like K2-18b."];
 
     //    Credits: WikiNews, CC BY 2.5 license (https://en.wikinews.org/wiki/Astronomers_find_water_vapour_in_atmosphere_of_exoplanet_K2-18b)
-    let output = summarization_model.summarize(&input);
+    let output = summarization_model.summarize(&input)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(

--- a/tests/reformer.rs
+++ b/tests/reformer.rs
@@ -64,7 +64,7 @@ fn test_generation_reformer() -> anyhow::Result<()> {
 
     let input_context_1 = "The really great men must, I think,";
     let input_context_2 = "It was a gloom winter night, and";
-    let output = model.generate(&[input_context_1, input_context_2], None);
+    let output = model.generate(&[input_context_1, input_context_2], None)?;
 
     assert_eq!(output.len(), 2);
     assert_eq!(output[0], " The really great men must, I think, anyway waiting for some unknown reason, but Nikodim Fomitch and Ilya Petrovitch looked at him anguish invitable incidently at him. He could not resist an impression which might be setting");

--- a/tests/t5.rs
+++ b/tests/t5.rs
@@ -102,7 +102,7 @@ on K2-18b lasts 33 Earth days. According to The Guardian, astronomers were optim
 telescope — scheduled for launch in 2021 — and the European Space Agency's 2028 ARIEL program, could reveal more \
 about exoplanets like K2-18b."];
 
-    let output = model.summarize(&input);
+    let output = model.summarize(&input)?;
 
     assert_eq! (
     output[0],

--- a/tests/xlnet.rs
+++ b/tests/xlnet.rs
@@ -222,7 +222,7 @@ fn xlnet_generation_beam_search() -> anyhow::Result<()> {
     let model = TextGenerationModel::new(generate_config)?;
 
     let input_context = "Once upon a time,";
-    let output = model.generate(&[input_context], None);
+    let output = model.generate(&[input_context], None)?;
 
     assert_eq!(output.len(), 1);
     assert_eq!(


### PR DESCRIPTION
Text generation traits and pipelines (including conversation, summarization and translation) now return a `Result` for improved error handling

Fixes https://github.com/guillaume-be/rust-bert/issues/436