### PR TITLE
Bump tch dependency to 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ features = ["doc-only"]
 
 [dependencies]
 rust_tokenizers = "8.1.1"
-tch = { version = "0.17.0", features = ["download-libtorch"] }
+tch = { version = "0.24.0", features = ["download-libtorch"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "5"


### PR DESCRIPTION
Update Cargo.toml to use tch = 0.24.0 (was 0.17.0) while keeping the download-libtorch feature.