### PR TITLE
Update tch crate for compatibility with pytorch v2.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ features = ["doc-only"]
 
 [dependencies]
 rust_tokenizers = "8.1.1"
-tch = { version = "0.24.0", features = ["download-libtorch"] }
+tch = "0.24.0"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ features = ["doc-only"]
 
 [dependencies]
 rust_tokenizers = "8.1.1"
-tch = { version = "0.17.0", features = ["download-libtorch"] }
+tch = { version = "0.24.0", features = ["download-libtorch"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 ordered-float = "5"
@@ -88,7 +88,7 @@ regex = "1.11"
 cached-path = { version = "0.8", default-features = false, optional = true }
 dirs = { version = "6", optional = true }
 lazy_static = { version = "1", optional = true }
-ort = { version = "1.16.3", optional = true, default-features = false, features = [
+ort = { version = "2.0.0-rc.12", optional = true, default-features = false, features = [
     "half",
 ] }
 ndarray = { version = "0.15", optional = true }
@@ -107,7 +107,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }
-ort = { version = "1.16.3", features = ["load-dynamic"] }
+ort = { version = "2.0.0-rc.12", features = ["load-dynamic"] }
 
 [[example]]
 name = "onnx-masked-lm"


### PR DESCRIPTION
The current version of tch requires pytorch v2.4.0, which no longer compiles on LLVM v20 and above. I personally need the higher version for local builds on mac os. If this PR is useful please consider implementing it.